### PR TITLE
add custom gltf JSON schemas

### DIFF
--- a/schemas/animation.schema.json
+++ b/schemas/animation.schema.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "animation.schema.json",
+  "title": "Animation",
+  "description": "Animation data for an asset.",
+  "type": "object",
+  "properties": {
+    "noAnimation": {
+      "description": "Empty animation data.",
+      "type": "object",
+      "properties": {
+        "properties": {
+          "$comment": "inspect() creates a 'properties' object. Do not confuse with the 'properties' keyword.",
+          "type": "array",
+          "items": {},
+          "minItems": 0,
+          "maxItems": 0,
+          "errorMessage": "Animation is currently not supported."
+        }
+      },
+      "required": ["properties"]
+    }
+  }
+}

--- a/schemas/assetBeard.schema.json
+++ b/schemas/assetBeard.schema.json
@@ -1,0 +1,90 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "assetBeard.schema.json",
+  "title": "Beard Asset",
+  "description": "A Ready Player Me glTF binary validation schema for beards.",
+  "type": "object",
+  "properties": {
+    "scenes": { "$ref": "scene.schema.json#/$defs/singleMeshScene" },
+    "meshes": {
+      "type": "object",
+      "properties": {
+        "properties": {
+          "$comment": "inspect() creates a 'properties' object. Do not confuse with the 'properties' keyword.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "description": "Name of the mesh.",
+                "$ref": "meshNames.schema.json#/properties/beard"
+              },
+              "attributes": {
+                "$ref": "meshAttributes.schema.json#/properties/unskinned"
+              },
+              "glPrimitives": {
+                "$ref": "meshTriangleCount.schema.json#/properties/beard"
+              }
+            },
+            "allOf": [{ "$ref": "commonMesh.schema.json" }],
+            "required": [
+              "name",
+              "mode",
+              "primitives",
+              "glPrimitives",
+              "vertices",
+              "indices",
+              "attributes",
+              "instances",
+              "size"
+            ]
+          }
+        }
+      }
+    },
+    "materials": {
+      "type": "object",
+      "properties": {
+        "properties": {
+          "$comment": "inspect() creates a 'properties' object. Do not confuse with the 'properties' keyword.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "description": "Name of the material.",
+                "$ref": "materialNames.schema.json#/properties/beard"
+              },
+              "textures": {
+                "$ref": "commonMaterial.schema.json#/$defs/normalOnlyTextureChannels"
+              },
+              "doubleSided": {
+                "$ref": "commonMaterial.schema.json#/$defs/singleSided"
+              },
+              "alphaMode": {
+                "$ref": "commonMaterial.schema.json#/$defs/opaqueAlphaMode"
+              }
+            },
+            "allOf": [{ "$ref": "commonMaterial.schema.json" }],
+            "required": [
+              "name",
+              "instances",
+              "textures",
+              "alphaMode",
+              "doubleSided"
+            ]
+          },
+          "minItems": 1,
+          "maxItems": 1,
+          "errorMessage": {
+            "minItems": "Missing material! Beard asset must have exactly one material.",
+            "maxItems": "Too many materials! Beard asset must have exactly one material."
+          }
+        }
+      }
+    },
+    "textures": { "$ref": "commonTexture.schema.json#/$defs/normalMap" },
+    "animations": { "$ref": "animation.schema.json#/properties/noAnimation" }
+  },
+  "required": ["scenes", "meshes", "materials"]
+}

--- a/schemas/assetFacewear.schema.json
+++ b/schemas/assetFacewear.schema.json
@@ -1,0 +1,90 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "assetFacewear.schema.json",
+  "title": "Facewear Asset",
+  "description": "A Ready Player Me glTF binary validation schema for facewear.",
+  "type": "object",
+  "properties": {
+    "scenes": { "$ref": "scene.schema.json#/$defs/singleMeshScene" },
+    "meshes": {
+      "type": "object",
+      "properties": {
+        "properties": {
+          "$comment": "inspect() creates a 'properties' object. Do not confuse with the 'properties' keyword.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "description": "Name of the mesh.",
+                "$ref": "meshNames.schema.json#/properties/facewear"
+              },
+              "attributes": {
+                "$ref": "meshAttributes.schema.json#/properties/unskinned"
+              },
+              "glPrimitives": {
+                "$ref": "meshTriangleCount.schema.json#/properties/facewear"
+              }
+            },
+            "allOf": [{ "$ref": "commonMesh.schema.json" }],
+            "required": [
+              "name",
+              "mode",
+              "primitives",
+              "glPrimitives",
+              "vertices",
+              "indices",
+              "attributes",
+              "instances",
+              "size"
+            ]
+          }
+        }
+      }
+    },
+    "materials": {
+      "type": "object",
+      "properties": {
+        "properties": {
+          "$comment": "inspect() creates a 'properties' object. Do not confuse with the 'properties' keyword.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "description": "Name of the material.",
+                "$ref": "materialNames.schema.json#/properties/facewear"
+              },
+              "textures": {
+                "$ref": "commonMaterial.schema.json#/$defs/allTextureChannels"
+              },
+              "doubleSided": {
+                "$ref": "commonMaterial.schema.json#/$defs/anySided"
+              },
+              "alphaMode": {
+                "$ref": "commonMaterial.schema.json#/$defs/anyAlphaMode"
+              }
+            },
+            "allOf": [{ "$ref": "commonMaterial.schema.json" }],
+            "required": [
+              "name",
+              "instances",
+              "textures",
+              "alphaMode",
+              "doubleSided"
+            ]
+          },
+          "minItems": 1,
+          "maxItems": 2,
+          "errorMessage": {
+            "minItems": "Missing material! Facewear asset must have at least 1 material.",
+            "maxItems": "Too many materials! Facewear asset must have at most 2 materials, one opaque and one transparent."
+          }
+        }
+      }
+    },
+    "textures": { "$ref": "commonTexture.schema.json#/$defs/fullPBR" },
+    "animations": { "$ref": "animation.schema.json#/properties/noAnimation" }
+  },
+  "required": ["scenes", "meshes", "materials", "textures"]
+}

--- a/schemas/assetGlasses.schema.json
+++ b/schemas/assetGlasses.schema.json
@@ -1,0 +1,90 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "assetGlasses.schema.json",
+  "title": "Glasses Asset",
+  "description": "A Ready Player Me glTF binary validation schema for glasses.",
+  "type": "object",
+  "properties": {
+    "scenes": { "$ref": "scene.schema.json#/$defs/singleMeshScene" },
+    "meshes": {
+      "type": "object",
+      "properties": {
+        "properties": {
+          "$comment": "inspect() creates a 'properties' object. Do not confuse with the 'properties' keyword.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "description": "Name of the mesh.",
+                "$ref": "meshNames.schema.json#/properties/glasses"
+              },
+              "attributes": {
+                "$ref": "meshAttributes.schema.json#/properties/unskinned"
+              },
+              "glPrimitives": {
+                "$ref": "meshTriangleCount.schema.json#/properties/glasses"
+              }
+            },
+            "allOf": [{ "$ref": "commonMesh.schema.json" }],
+            "required": [
+              "name",
+              "mode",
+              "primitives",
+              "glPrimitives",
+              "vertices",
+              "indices",
+              "attributes",
+              "instances",
+              "size"
+            ]
+          }
+        }
+      }
+    },
+    "materials": {
+      "type": "object",
+      "properties": {
+        "properties": {
+          "$comment": "inspect() creates a 'properties' object. Do not confuse with the 'properties' keyword.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "description": "Name of the material.",
+                "$ref": "materialNames.schema.json#/properties/glasses"
+              },
+              "textures": {
+                "$ref": "commonMaterial.schema.json#/$defs/allTextureChannels"
+              },
+              "doubleSided": {
+                "$ref": "commonMaterial.schema.json#/$defs/anySided"
+              },
+              "alphaMode": {
+                "$ref": "commonMaterial.schema.json#/$defs/anyAlphaMode"
+              }
+            },
+            "allOf": [{ "$ref": "commonMaterial.schema.json" }],
+            "required": [
+              "name",
+              "instances",
+              "textures",
+              "alphaMode",
+              "doubleSided"
+            ]
+          },
+          "minItems": 1,
+          "maxItems": 2,
+          "errorMessage": {
+            "minItems": "Missing material! Glasses asset must have at least 1 material.",
+            "maxItems": "Too many materials! Glasses asset must have at most 2 materials, one opaque and one transparent."
+          }
+        }
+      }
+    },
+    "textures": { "$ref": "commonTexture.schema.json#/$defs/fullPBR" },
+    "animations": { "$ref": "animation.schema.json#/properties/noAnimation" }
+  },
+  "required": ["scenes", "meshes", "materials", "textures"]
+}

--- a/schemas/assetHair.schema.json
+++ b/schemas/assetHair.schema.json
@@ -1,0 +1,90 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "assetHair.schema.json",
+  "title": "Hair Asset",
+  "description": "A Ready Player Me glTF binary validation schema for hair.",
+  "type": "object",
+  "properties": {
+    "scenes": { "$ref": "scene.schema.json#/$defs/singleMeshScene" },
+    "meshes": {
+      "type": "object",
+      "properties": {
+        "properties": {
+          "$comment": "inspect() creates a 'properties' object. Do not confuse with the 'properties' keyword.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "description": "Name of the mesh.",
+                "$ref": "meshNames.schema.json#/properties/hair"
+              },
+              "attributes": {
+                "$ref": "meshAttributes.schema.json#/properties/unskinned"
+              },
+              "glPrimitives": {
+                "$ref": "meshTriangleCount.schema.json#/properties/hair"
+              }
+            },
+            "allOf": [{ "$ref": "commonMesh.schema.json" }],
+            "required": [
+              "name",
+              "mode",
+              "primitives",
+              "glPrimitives",
+              "vertices",
+              "indices",
+              "attributes",
+              "instances",
+              "size"
+            ]
+          }
+        }
+      }
+    },
+    "materials": {
+      "type": "object",
+      "properties": {
+        "properties": {
+          "$comment": "inspect() creates a 'properties' object. Do not confuse with the 'properties' keyword.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "description": "Name of the material.",
+                "$ref": "materialNames.schema.json#/properties/hair"
+              },
+              "textures": {
+                "$ref": "commonMaterial.schema.json#/$defs/normalOnlyTextureChannels"
+              },
+              "doubleSided": {
+                "$ref": "commonMaterial.schema.json#/$defs/singleSided"
+              },
+              "alphaMode": {
+                "$ref": "commonMaterial.schema.json#/$defs/opaqueAlphaMode"
+              }
+            },
+            "allOf": [{ "$ref": "commonMaterial.schema.json" }],
+            "required": [
+              "name",
+              "instances",
+              "textures",
+              "alphaMode",
+              "doubleSided"
+            ]
+          },
+          "minItems": 1,
+          "maxItems": 1,
+          "errorMessage": {
+            "minItems": "Missing material! Hair asset must have exactly one material.",
+            "maxItems": "Too many materials! Hair asset must have exactly one material."
+          }
+        }
+      }
+    },
+    "textures": { "$ref": "commonTexture.schema.json#/$defs/normalMap" },
+    "animations": { "$ref": "animation.schema.json#/properties/noAnimation" }
+  },
+  "required": ["scenes", "meshes", "materials"]
+}

--- a/schemas/assetHeadwear.schema.json
+++ b/schemas/assetHeadwear.schema.json
@@ -1,0 +1,138 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "assetHeadwear.schema.json",
+  "title": "Headwear Asset",
+  "description": "A Ready Player Me glTF binary validation schema for headwear.",
+  "type": "object",
+  "properties": {
+    "scenes": {
+      "type": "object",
+      "properties": {
+        "properties": {
+          "$comment": "inspect() creates a 'properties' object. Do not confuse with the 'properties' keyword.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": { "description": "Name of the scene.", "type": "string" },
+              "rootName": {
+                "description": "Name of the root node in the scene.",
+                "oneOf": [
+                  { "$ref": "meshNames.schema.json#/properties/headwear" },
+                  { "type": "string", "const": "Headwear_Rig" }
+                ],
+                "errorMessage": "The root node should either be an unskinned mesh, or a skeleton named 'Headwear_Rig'. Mesh name is ${/meshes/properties/0/name}. Found root ${0} instead."
+              }
+            },
+            "allOf": [{ "$ref": "scene.schema.json#/$defs/headBbox" }],
+            "required": ["rootName"],
+            "errorMessage": {
+              "required": {
+                "rootName": "Missing root node property in the scene ${0/name}."
+              }
+            }
+          },
+          "minItems": 1,
+          "maxItems": 1,
+          "errorMessage": {
+            "minItems": "There must be exactly one scene.",
+            "maxItems": "There must be only one scene."
+          }
+        }
+      }
+    },
+    "meshes": {
+      "type": "object",
+      "properties": {
+        "properties": {
+          "$comment": "inspect() creates a 'properties' object. Do not confuse with the 'properties' keyword.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "description": "Name of the mesh.",
+                "$ref": "meshNames.schema.json#/properties/headwear"
+              },
+              "attributes": {
+                "oneOf": [
+                  {
+                    "$ref": "meshAttributes.schema.json#/properties/skinned"
+                  },
+                  {
+                    "$ref": "meshAttributes.schema.json#/properties/unskinned"
+                  }
+                ]
+              },
+              "glPrimitives": {
+                "$ref": "meshTriangleCount.schema.json#/properties/headwear"
+              }
+            },
+            "allOf": [{ "$ref": "commonMesh.schema.json" }],
+            "required": [
+              "name",
+              "mode",
+              "primitives",
+              "glPrimitives",
+              "vertices",
+              "indices",
+              "attributes",
+              "instances",
+              "size"
+            ]
+          }
+        }
+      }
+    },
+    "materials": {
+      "type": "object",
+      "properties": {
+        "properties": {
+          "$comment": "inspect() creates a 'properties' object. Do not confuse with the 'properties' keyword.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "description": "Name of the material.",
+                "$ref": "materialNames.schema.json#/properties/headwear"
+              },
+              "textures": {
+                "$ref": "commonMaterial.schema.json#/$defs/allTextureChannels"
+              },
+              "doubleSided": {
+                "$ref": "commonMaterial.schema.json#/$defs/anySided"
+              },
+              "alphaMode": {
+                "$ref": "commonMaterial.schema.json#/$defs/anyAlphaMode"
+              }
+            },
+            "allOf": [{ "$ref": "commonMaterial.schema.json" }],
+            "required": [
+              "name",
+              "instances",
+              "textures",
+              "alphaMode",
+              "doubleSided"
+            ]
+          },
+          "minItems": 1,
+          "maxItems": 2,
+          "errorMessage": {
+            "minItems": "Missing material! Headwear asset must have at least 1 material.",
+            "maxItems": "Too many materials! Headwear asset must have at most 2 materials, one opaque and one transparent."
+          }
+        }
+      }
+    },
+    "textures": { "$ref": "commonTexture.schema.json#/$defs/fullPBR" },
+    "animations": { "$ref": "animation.schema.json#/properties/noAnimation" },
+    "joints": {
+      "oneOf": [
+        { "$ref": "joints.schema.json#/$defs/noSkeleton" },
+        { "$ref": "joints.schema.json#/$defs/headwear" }
+      ]
+    }
+  },
+  "required": ["scenes", "meshes", "materials", "textures"]
+}

--- a/schemas/assetNonCustomizableAvatar.schema.json
+++ b/schemas/assetNonCustomizableAvatar.schema.json
@@ -1,0 +1,227 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "assetNonCustomizableAvatar.schema.json",
+  "title": "Non-Customizable Avatar Asset",
+  "description": "A Ready Player Me glTF binary validation schema for a non-Customizable avatar.",
+  "type": "object",
+  "properties": {
+    "scenes": { "$ref": "scene.schema.json#/$defs/fullbodyOutfitScene" },
+    "meshes": {
+      "type": "object",
+      "properties": {
+        "totalTriangleCount": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 30000,
+          "errorMessage": {
+            "minimum": "Too few triangles! Non-customizable avatars must have at least 1 triangle.",
+            "maximum": "Too many triangles (${0})! Non-customizable avatars must have no more than a total of 30,000 triangles."
+          }
+        },
+        "properties": {
+          "$comment": "inspect() creates a 'properties' object. Do not confuse with the 'properties' keyword.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "description": "Name of the mesh.",
+                "$ref": "meshNames.schema.json#/properties/nonCustomizableAvatar"
+              },
+              "attributes": {
+                "$ref": "meshAttributes.schema.json#/properties/skinned"
+              },
+              "glPrimitives": { "type": "integer" }
+            },
+            "allOf": [
+              { "$ref": "commonMesh.schema.json" },
+              {
+                "if": {
+                  "properties": {
+                    "name": { "const": "Wolf3D_Body_Custom" }
+                  }
+                },
+                "then": {
+                  "properties": {
+                    "glPrimitives": {
+                      "$ref": "meshTriangleCount.schema.json#/properties/bodyCustom"
+                    }
+                  }
+                }
+              },
+              {
+                "if": {
+                  "properties": {
+                    "name": { "type": "string", "enum": ["EyeLeft", "EyeRight"] }
+                  }
+                },
+                "then": {
+                  "properties": {
+                    "glPrimitives": {
+                      "$ref": "meshTriangleCount.schema.json#/properties/eye"
+                    }
+                  }
+                }
+              },
+              {
+                "if": {
+                  "properties": {
+                    "name": { "const": "Wolf3D_Head_Custom" }
+                  }
+                },
+                "then": {
+                  "properties": {
+                    "glPrimitives": {
+                      "$ref": "meshTriangleCount.schema.json#/properties/headCustom"
+                    }
+                  }
+                }
+              },
+              {
+                "if": {
+                  "properties": {
+                    "name": { "const": "Wolf3D_Outfit_Bottom" }
+                  }
+                },
+                "then": {
+                  "properties": {
+                    "glPrimitives": {
+                      "$ref": "meshTriangleCount.schema.json#/properties/outfitBottom"
+                    }
+                  }
+                }
+              },
+              {
+                "if": {
+                  "properties": {
+                    "name": { "const": "Wolf3D_Outfit_Footwear" }
+                  }
+                },
+                "then": {
+                  "properties": {
+                    "glPrimitives": {
+                      "$ref": "meshTriangleCount.schema.json#/properties/outfitFootwear"
+                    }
+                  }
+                }
+              },
+              {
+                "if": {
+                  "properties": {
+                    "name": { "const": "Wolf3D_Outfit_Top" }
+                  }
+                },
+                "then": {
+                  "properties": {
+                    "glPrimitives": {
+                      "$ref": "meshTriangleCount.schema.json#/properties/outfitTop"
+                    }
+                  }
+                }
+              },
+              {
+                "if": {
+                  "properties": {
+                    "name": { "const": "Wolf3D_Teeth" }
+                  }
+                },
+                "then": {
+                  "properties": {
+                    "glPrimitives": {
+                      "$ref": "meshTriangleCount.schema.json#/properties/teeth"
+                    }
+                  }
+                }
+              }
+            ],
+            "required": [
+              "name",
+              "mode",
+              "primitives",
+              "glPrimitives",
+              "vertices",
+              "indices",
+              "attributes",
+              "instances",
+              "size"
+            ]
+          },
+          "minItems": 1,
+          "maxItems": 8,
+          "errorMessage": {
+            "minItems": "Missing mesh! Non-customizable avatars must have at least 1 mesh.",
+            "maxItems": "Too many meshes! Non-customizable avatars must have no more than 8 meshes."
+          }
+        }
+      }
+    },
+    "materials": {
+      "type": "object",
+      "properties": {
+        "properties": {
+          "$comment": "inspect() creates a 'properties' object. Do not confuse with the 'properties' keyword.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "description": "Name of the material.",
+                "$ref": "materialNames.schema.json#/properties/nonCustomizableAvatar"
+              },
+              "textures": {
+                "$ref": "commonMaterial.schema.json#/$defs/allTextureChannels"
+              },
+              "doubleSided": {
+                "$ref": "commonMaterial.schema.json#/$defs/singleSided"
+              },
+              "alphaMode": {
+                "$ref": "commonMaterial.schema.json#/$defs/opaqueAlphaMode"
+              }
+            },
+            "allOf": [
+              { "$ref": "commonMaterial.schema.json" }
+            ],
+            "required": [
+              "name",
+              "instances",
+              "textures",
+              "alphaMode",
+              "doubleSided"
+            ]
+          },
+          "uniqueItems": true,
+          "minItems": 1,
+          "maxItems": 7,
+          "errorMessage": {
+            "minItems": "Missing material! This avatar must have at least 1 material. Found ${/materials/properties/length}.",
+            "maxItems": "Too many materials! This avatar only supports up to 7 materials (eyes share a material). Found ${/materials/properties/length}."
+          }
+        }
+      }
+    },
+    "textures": { "$ref": "commonTexture.schema.json#/$defs/fullPBR" },
+    "animations": { "$ref": "animation.schema.json#/properties/noAnimation" },
+    "joints" : { "$ref": "joints.schema.json#/$defs/skeletonV2WithEyes" }
+  },
+  "required": ["scenes", "meshes", "materials", "joints"],
+  "$defs":{
+    "nonCustomizableAvatarTextureCount": {
+      "type": "object",
+      "description": "A non-customizable avatar supports up to 7 materials with 5 maps each, totalling 35 maps.",
+      "properties": {
+        "textures": {
+          "type": "object",
+          "properties": {
+            "properties": {
+              "type": "array",
+              "maxItems": 35,
+              "errorMessage": {
+                "maxItems": "Too many texture maps (${0/length})! This Asset type ${/assetType} must have 35 maps at most."
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/schemas/assetOutfit.schema.json
+++ b/schemas/assetOutfit.schema.json
@@ -1,0 +1,208 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "assetOutfit.schema.json",
+  "title": "Fullbody Outfit Asset",
+  "description": "A Ready Player Me glTF binary validation schema for a fullbody outfit.",
+  "type": "object",
+  "properties": {
+    "scenes": { "$ref": "scene.schema.json#/$defs/fullbodyOutfitScene" },
+    "meshes": {
+      "type": "object",
+      "properties": {
+        "totalTriangleCount": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 20000,
+          "errorMessage": {
+            "minimum": "Too few triangles! Full-body outfit assets must have at least 1 triangle.",
+            "maximum": "Too many triangles (${0})! Full-body outfit assets must have no more than a total of 20,000 triangles."
+          }
+        },
+        "properties": {
+          "$comment": "inspect() creates a 'properties' object. Do not confuse with the 'properties' keyword.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "description": "Name of the mesh.",
+                "$ref": "meshNames.schema.json#/properties/outfit"
+              },
+              "attributes": {
+                "$ref": "meshAttributes.schema.json#/properties/skinned"
+              },
+              "glPrimitives": { "type": "integer" }
+            },
+            "allOf": [
+              { "$ref": "commonMesh.schema.json" },
+              {
+                "if": {
+                  "properties": {
+                    "name": { "const": "Wolf3D_Body" }
+                  }
+                },
+                "then": {
+                  "properties": {
+                    "glPrimitives": {
+                      "$ref": "meshTriangleCount.schema.json#/properties/body"
+                    }
+                  }
+                }
+              },
+              {
+                "if": {
+                  "properties": {
+                    "name": { "const": "Wolf3D_Outfit_Bottom" }
+                  }
+                },
+                "then": {
+                  "properties": {
+                    "glPrimitives": {
+                      "$ref": "meshTriangleCount.schema.json#/properties/outfitBottom"
+                    }
+                  }
+                }
+              },
+              {
+                "if": {
+                  "properties": {
+                    "name": { "const": "Wolf3D_Outfit_Footwear" }
+                  }
+                },
+                "then": {
+                  "properties": {
+                    "glPrimitives": {
+                      "$ref": "meshTriangleCount.schema.json#/properties/outfitFootwear"
+                    }
+                  }
+                }
+              },
+              {
+                "if": {
+                  "properties": {
+                    "name": { "const": "Wolf3D_Outfit_Top" }
+                  }
+                },
+                "then": {
+                  "properties": {
+                    "glPrimitives": {
+                      "$ref": "meshTriangleCount.schema.json#/properties/outfitTop"
+                    }
+                  }
+                }
+              }
+            ],
+            "required": [
+              "name",
+              "mode",
+              "primitives",
+              "glPrimitives",
+              "vertices",
+              "indices",
+              "attributes",
+              "instances",
+              "size"
+            ]
+          },
+          "minItems": 1,
+          "maxItems": 4,
+          "errorMessage": {
+            "minItems": "Missing mesh! Full-body outfit asset must have at least 1 mesh.",
+            "maxItems": "Too many meshes! Full-body outfit asset must have no more than 4 meshes."
+          }
+        }
+      }
+    },
+    "materials": {
+      "type": "object",
+      "properties": {
+        "properties": {
+          "$comment": "inspect() creates a 'properties' object. Do not confuse with the 'properties' keyword.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "description": "Name of the material.",
+                "$ref": "materialNames.schema.json#/properties/outfit"
+              },
+              "textures": {
+                "description": "Textures used by the outfit materials. The 'Wolf3D_Body' material uses only the 'normalTexture'. All other materials can use all channels."
+              },
+              "doubleSided": {
+                "$ref": "commonMaterial.schema.json#/$defs/singleSided"
+              },
+              "alphaMode": {
+                "$ref": "commonMaterial.schema.json#/$defs/opaqueAlphaMode"
+              }
+            },
+            "allOf": [
+              { "$ref": "commonMaterial.schema.json" },
+              {
+                "if": {
+                  "properties": {
+                    "name": {
+                      "const": "Wolf3D_Body"
+                    }
+                  }
+                },
+                "then": {
+                  "properties": {
+                    "textures": {
+                      "$ref": "commonMaterial.schema.json#/$defs/normalOnlyTextureChannels"
+                    }
+                  }
+                },
+                "else": {
+                  "properties": {
+                    "textures": {
+                      "$ref": "commonMaterial.schema.json#/$defs/allTextureChannels"
+                    }
+                  }
+                }
+              }
+            ],
+            "required": [
+              "name",
+              "instances",
+              "textures",
+              "alphaMode",
+              "doubleSided"
+            ]
+          },
+          "uniqueItems": true,
+          "minItems": { "$data": "/meshes/properties/length" },
+          "maxItems": { "$data": "/meshes/properties/length" },
+          "errorMessage": {
+            "minItems": "Missing material! This outfit asset must have ${/meshes/properties/length} materials, one for each mesh. Found ${/materials/properties/length}.",
+            "maxItems": "Too many materials! This outfit asset must have ${/meshes/properties/length} materials, one for each mesh. Found ${/materials/properties/length}."
+          }
+        }
+      }
+    },
+    "textures": { "$ref": "commonTexture.schema.json#/$defs/fullPBR" },
+    "animations": { "$ref": "animation.schema.json#/properties/noAnimation" },
+    "joints" : {"allOf": [{ "$ref": "joints.schema.json#/$defs/skeletonV2" }, { "$ref": "joints.schema.json#/$defs/skeletonV2/$defs/maxJoints" }]}
+  },
+  "required": ["scenes", "meshes", "materials", "joints"],
+  "$defs": {
+    "outfitTextureCount": {
+      "type": "object",
+      "properties": {
+        "textures": {
+          "type": "object",
+          "properties": {
+            "properties": {
+              "type": "array",
+              "maxItems": 16,
+              "$comment": "A full-body outfit asset supports up to 3 materials with up to 5 maps each and 1 body normal map, totalling 16 maps.",
+              "errorMessage": {
+                "maxItems": "Too many texture maps (${0/length})! This Asset type ${/assetType} must have 16 maps at most."
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/schemas/assetShirt.schema.json
+++ b/schemas/assetShirt.schema.json
@@ -1,0 +1,90 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "assetShirt.schema.json",
+  "title": "Half-body Shirt Asset",
+  "description": "A Ready Player Me glTF binary validation schema for half-body shirts.",
+  "type": "object",
+  "properties": {
+    "scenes": { "$ref": "scene.schema.json#/$defs/singleMeshScene" },
+    "meshes": {
+      "type": "object",
+      "properties": {
+        "properties": {
+          "$comment": "inspect() creates a 'properties' object. Do not confuse with the 'properties' keyword.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "description": "Name of the mesh.",
+                "$ref": "meshNames.schema.json#/properties/halfbodyShirt"
+              },
+              "attributes": {
+                "$ref": "meshAttributes.schema.json#/properties/unskinned"
+              },
+              "glPrimitives": {
+                "$ref": "meshTriangleCount.schema.json#/properties/halfbodyShirt"
+              }
+            },
+            "allOf": [{ "$ref": "commonMesh.schema.json" }],
+            "required": [
+              "name",
+              "mode",
+              "primitives",
+              "glPrimitives",
+              "vertices",
+              "indices",
+              "attributes",
+              "instances",
+              "size"
+            ]
+          }
+        }
+      }
+    },
+    "materials": {
+      "type": "object",
+      "properties": {
+        "properties": {
+          "$comment": "inspect() creates a 'properties' object. Do not confuse with the 'properties' keyword.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "description": "Name of the material.",
+                "$ref": "materialNames.schema.json#/properties/halfbodyShirt"
+              },
+              "textures": {
+                "$ref": "commonMaterial.schema.json#/$defs/allTextureChannels"
+              },
+              "doubleSided": {
+                "$ref": "commonMaterial.schema.json#/$defs/singleSided"
+              },
+              "alphaMode": {
+                "$ref": "commonMaterial.schema.json#/$defs/opaqueAlphaMode"
+              }
+            },
+            "allOf": [{ "$ref": "commonMaterial.schema.json" }],
+            "required": [
+              "name",
+              "instances",
+              "textures",
+              "alphaMode",
+              "doubleSided"
+            ]
+          },
+          "minItems": 1,
+          "maxItems": 1,
+          "errorMessage": {
+            "minItems": "Missing material! Shirt asset must have at least 1 material.",
+            "maxItems": "Too many materials! Shirt asset must have at most 1 material."
+          }
+        }
+      }
+    },
+    "textures": { "$ref": "commonTexture.schema.json#/$defs/fullPBR" },
+    "animations": { "$ref": "animation.schema.json#/properties/noAnimation" }
+  },
+  "required": ["scenes", "meshes", "materials", "textures"]
+}

--- a/schemas/commonMaterial.schema.json
+++ b/schemas/commonMaterial.schema.json
@@ -1,0 +1,130 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "commonMaterial.schema.json",
+  "title": "Common Material Properties",
+  "description": "Validation schema for common properties of materials.",
+  "type": "object",
+  "properties": {
+    "instances": {
+      "description": "Number of instances of this material.",
+      "type": "integer",
+      "const": 1,
+      "errorMessage": "Material ${1/name} must have exactly one instance."
+    },
+    "baseColorFactor": {
+      "type": "array",
+      "items": {
+        "type": "number",
+        "minimum": 1.0,
+        "maximum": 1.0,
+        "errorMessage": "Base color factors other than 1.0 are not supported. Found ${0} in material ${1/name}."
+      },
+      "description": "The factors for the base color of the material.",
+      "default": [1.0, 1.0, 1.0, 1.0],
+      "minItems": 4,
+      "maxItems": 4,
+      "errorMessage": "The factors for the base color of the material ${1/name} must be [1.0, 1.0, 1.0, 1.0]. Found ${0}."
+    },
+    "emissiveFactor": {
+      "type": "array",
+      "items": {
+        "type": "number",
+        "minimum": 0.0
+      },
+      "description": "The factors for the emissive color of the material.",
+      "default": [0.0, 0.0, 0.0],
+      "minItems": 3,
+      "maxItems": 3,
+      "errorMessage": "The factors for the emissive color of the material ${1/name} must be an array of 3 numbers. Found ${0}."
+    },
+    "metallicFactor": {
+      "type": "number",
+      "description": "The factor for the metalness of the material.",
+      "default": 1.0,
+      "minimum": 0.0,
+      "maximum": 1.0
+    },
+    "roughnessFactor": {
+      "type": "number",
+      "description": "The factor for the roughness of the material.",
+      "default": 1.0,
+      "minimum": 0.0,
+      "maximum": 1.0
+    }
+  },
+  "$defs": {
+    "normalOnlyTextureChannels": {
+      "description": "Texture map channels used by this material. This material only allows the use of a normal map.",
+      "type": "array",
+      "items": {
+        "type": "string",
+        "const": "normalTexture",
+        "errorMessage": "Material ${2/name} must only use the normal map channel. Found ${0} instead."
+      },
+      "minItems": 0,
+      "maxItems": 1,
+      "errorMessage": {
+        "maxItems": "Material ${1/name} can only use the optional normal map channel. Found ${0} instead."
+      }
+    },
+    "allTextureChannels": {
+      "description": "Texture map channels used by this material. This material supports base color, emissive, metallicRoughness, normal, and occlusion.",
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": ["baseColorTexture", "emissiveTexture", "metallicRoughnessTexture", "normalTexture", "occlusionTexture"],
+        "errorMessage": "Material ${2/name} uses unsupported texture slot ${0}! Supported slots are baseColorTexture, emissiveTexture, metallicRoughnessTexture, normalTexture, and occlusionTexture."
+      },
+      "contains": {
+        "type": "string",
+        "const": "baseColorTexture"
+      },
+      "minContains": 1,
+      "uniqueItems": true,
+      "minItems": 1,
+      "maxItems": 5,
+      "errorMessage": {
+        "contains": "Material ${1/name} must use a baseColorTexture.",
+        "minItems": "Material ${1/name} must use at least a baseColorTexture. Found ${0/length} texture maps: ${0}.",
+        "maxItems": "Material ${1/name} uses too many texture slots. 5 are supported. Found ${0}."
+      }
+    },
+    "singleSided": {
+      "description": "Double sided rendering of the material.",
+      "type": "boolean",
+      "const": false,
+      "errorMessage": "Material ${1/name} must be single-sided (have backface culling enabled)."
+    },
+    "anySided": {
+      "description": "Double sided rendering of the material.",
+      "type": "boolean"
+    },
+    "opaqueAlphaMode": {
+      "description": "Opaque material alpha mode.",
+      "type": "string",
+      "const": "OPAQUE",
+      "errorMessage": "Material ${1/name} must be opaque."
+    },
+    "anyAlphaMode": {
+      "default": "OPAQUE",
+      "description": "The alpha rendering mode of the material.",
+      "anyOf": [
+        {
+          "const": "OPAQUE",
+          "description": "The alpha value is ignored, and the rendered output is fully opaque."
+        },
+        {
+          "const": "MASK",
+          "description": "The rendered output is either fully opaque or fully transparent depending on the alpha value and the specified `alphaCutoff` value; the exact appearance of the edges **MAY** be subject to implementation-specific techniques such as \"`Alpha-to-Coverage`\"."
+        },
+        {
+          "const": "BLEND",
+          "description": "The alpha value is used to composite the source and destination areas. The rendered output is combined with the background using the normal painting operation (i.e. the Porter and Duff over operator)."
+        },
+        {
+          "type": "string"
+        }
+      ]
+    }
+  }
+}

--- a/schemas/commonMesh.schema.json
+++ b/schemas/commonMesh.schema.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "commonMesh.schema.json",
+  "title": "Common Mesh Properties",
+  "description": "Validation schema for common properties of meshes.",
+  "type": "object",
+  "properties": {
+    "mode": {
+      "description": "The rendering mode of the mesh. Only TRIANGLES are supported.",
+      "type": "array",
+      "prefixItems": [{ "const": "TRIANGLES" }],
+      "minItems": 1,
+      "maxItems": 1,
+      "errorMessage": "Rendering mode must be TRIANGLES."
+    },
+    "primitives": {
+      "description": "Number of geometry primitives to be rendered with the given material.",
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 2,
+      "errorMessage": "Number of primitives in the mesh must be 1, or 2 when an additional transparent material is used."
+    },
+    "indices": {
+      "description": "The index of the accessor that contains the vertex indices.",
+      "type": "array",
+      "prefixItems": [{ "const": "u16" }],
+      "minItems": 1,
+      "maxItems": 1,
+      "errorMessage": "Indices must be [\"u16\"] single-item array."
+    },
+    "instances": {
+      "description": "The number of instances to render.",
+      "const": 1,
+      "errorMessage": "Only 1 instance per mesh is supported."
+    },
+    "size": {
+      "description": "Byte size. Buffers stored as GLB binary chunk have an implicit limit of (2^32)-1 bytes.",
+      "type": "integer",
+      "maximum": 524288,
+      "errorMessage": "Maximum allowed mesh size is 512 kB."
+    }
+  },
+  "required": ["mode", "primitives"]
+}

--- a/schemas/commonTexture.schema.json
+++ b/schemas/commonTexture.schema.json
@@ -1,0 +1,194 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "commonTexture.schema.json",
+  "title": "Common Texture Map Properties",
+  "description": "Validation schema for common properties of texture maps.",
+  "type": "object",
+  "properties": {
+    "name": { "type": "string" },
+    "uri": { "type": "string" },
+    "instances": {
+      "type": "integer",
+      "minimum": 1,
+      "errorMessage": {
+        "minimum": "Texture map ${1/name} must be instanced at least once."
+      }
+    },
+    "mimeType": {
+      "type": "string",
+      "oneOf": [{ "const": "image/png" }, { "const": "image/jpeg" }],
+      "errorMessage": {
+        "oneOf": "Texture map ${1/name} must be encoded as PNG or JPEG. Found ${0} instead."
+      }
+    },
+    "compression": { "type": "string" },
+    "resolution": {
+      "description": "Image resolution data used for textures. Power of 2 and sqaure.",
+      "type": "string",
+      "oneOf": [
+        { "const": "1x1" },
+        { "const": "2x2" },
+        { "const": "4x4" },
+        { "const": "8x8" },
+        { "const": "16x16" },
+        { "const": "32x32" },
+        { "const": "64x64" },
+        { "const": "128x128" },
+        { "const": "256x256" },
+        { "const": "512x512" },
+        { "const": "1024x1024" }
+      ],
+      "errorMessage": "Image resolution for ${1/name} must be a power of 2 and square. Maximum 1024 x 1024. Found ${0} instead."
+    },
+    "size": {
+      "type": "integer",
+      "maximum": 2097152,
+      "errorMessage": {
+        "maximum": "Texture map ${1/name} exceeds maximum allowed storage size of 2 MB."
+      }
+    },
+    "gpuSize": {
+      "type": "integer",
+      "maximum": 6291456,
+      "errorMessage": {
+        "maximum": "Texture map ${1/name} exceeds maximum allowed GPU size of 6 MB when fully decompressed."
+      }
+    }
+  },
+  "$defs": {
+    "normalMap": {
+      "description": "For a single-mesh asset with only normal map support.",
+      "type": "object",
+      "properties": {
+        "properties": {
+          "$comment": "inspect() creates a 'properties' object. Do not confuse with the 'properties' keyword.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "slots": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "const": "normalTexture",
+                  "errorMessage": "This asset type only supports the use of a single normal map. Found ${0} instead."
+                },
+                "minItems": 0,
+                "maxItems": 1,
+                "errorMessage": {
+                  "maxItems": "Texture map ${1/name} used for too many slots. Used for ${0}."
+                }
+              }
+            },
+            "allOf": [{ "$ref": "commonTexture.schema.json" }],
+            "required": [
+              "name",
+              "uri",
+              "slots",
+              "instances",
+              "mimeType",
+              "compression",
+              "resolution",
+              "size",
+              "gpuSize"
+            ]
+          },
+          "minItems": 0,
+          "maxItems": 1,
+          "errorMessage": {
+            "maxItems": "Too many texture maps! This Asset type must have only one normal map."
+          }
+        }
+      }
+    },
+    "fullPBR": {
+      "description": "For a single- or multi-mesh asset with full PBR map support.",
+      "type": "object",
+      "properties": {
+        "properties": {
+          "$comment": "inspect() creates a 'properties' object. Do not confuse with the 'properties' keyword.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "slots": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "enum": [
+                    "baseColorTexture",
+                    "emissiveTexture",
+                    "metallicRoughnessTexture",
+                    "normalTexture",
+                    "occlusionTexture"
+                  ],
+                  "errorMessage": "Texture ${2/name} uses unsupported slot ${0}! Supported slots are baseColorTexture, emissiveTexture, metallicRoughnessTexture, normalTexture, and occlusionTexture."
+                },
+                "uniqueItems": true,
+                "minItems": 1,
+                "maxItems": 5,
+                "$comment": "Usually, only the metallicRoughness map is used in 2 slots, namely metallicRoughness & occlusion.",
+                "errorMessage": {
+                  "minItems": "Texture map ${1/name} must be used in at least 1 slot.",
+                  "maxItems": "Texture map ${1/name} used for too many slots (${0/length}). Used for ${0}."
+                }
+              }
+            },
+            "allOf": [{ "$ref": "commonTexture.schema.json" }],
+            "required": [
+              "name",
+              "uri",
+              "slots",
+              "instances",
+              "mimeType",
+              "compression",
+              "resolution",
+              "size",
+              "gpuSize"
+            ]
+          },
+          "minItems": 1,
+          "errorMessage": {
+            "minItems": "Too few texture maps (${0/length})! This Asset type ${/assetType} must have at least one base color texture map."
+          }
+        }
+      }
+    },
+    "singleMaterialTextureCount": {
+      "type": "object",
+      "description": "The single-mesh asset without transparency supports only 1 material with up to 5 texture maps.",
+      "properties": {
+        "textures": {
+          "type": "object",
+          "properties": {
+            "properties": {
+              "type": "array",
+              "maxItems": 5,
+              "errorMessage": {
+                "maxItems": "Too many texture maps (${0/length})! This Asset type ${/assetType} must have 5 maps at most."
+              }
+            }
+          }
+        }
+      }
+    },
+    "dualMaterialTextureCount": {
+      "description": "The single mesh assets support up to 2 materials (opaque + transparent) with 5 maps each.",
+      "type": "object",
+      "properties": {
+        "textures": {
+          "type": "object",
+          "properties": {
+            "properties": {
+              "type": "array",
+              "maxItems": 10,
+              "errorMessage": {
+                "maxItems": "Too many texture maps (${0/length})! This Asset type ${/assetType} must have 10 maps at most."
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/schemas/gltf-asset.schema.json
+++ b/schemas/gltf-asset.schema.json
@@ -1,0 +1,163 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "gltf-asset.schema.json",
+  "title": "Ready Player Me GLTF Asset Validation",
+  "description": "A Ready Player Me glTF binary asset validation schema. Validates augmented output of @gltf-transform/functions::inspect().",
+  "type": "object",
+  "properties": {
+    "assetType": {
+      "description": "The type of asset.",
+      "type": "string",
+      "default": "outfit",
+      "enum": [
+        "beard",
+        "facewear",
+        "glasses",
+        "hair",
+        "headwear",
+        "nonCustomizableAvatar",
+        "shirt",
+        "outfit"
+      ],
+      "errorMessage": {
+        "type": "Asset type should be a string.",
+        "enum": "Asset type should be one of the following: beard, facewear, glasses, hair, headwear, nonCustomizableAvatar, shirt, outfit. Found ${0}."
+      }
+    },
+    "transforms": {
+      "description": "The transforms of the objects (meshes & skeleton root).",
+      "type": "object",
+      "additionalProperties": {
+        "type": "array",
+        "minItems": 16,
+        "maxItems": 16,
+        "items": {
+          "type": "number"
+        },
+        "const": [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1],
+        "errorMessage": {
+          "const": "Transforms for ${0#} must be neutral (identity matrix: zero translation or rotation, scale of 1). Found ${0}.",
+          "_": "Transforms for ${0#} must be an array of 16 numbers (flattened 4x4 identity matrix). Found ${0/length} numbers."
+        }
+      }
+    },
+    "gltfErrors": {
+      "description": "The errors encountered during glTF validation.",
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "maxItems": 0,
+      "errorMessage": {
+        "maxItems": "Encountered errors codes from gltf-validator: ${0}."
+      }
+    }
+  },
+  "required": ["transforms", "gltfErrors"],
+  "$comment": "Below are the asset type specific schemas defined. Some asset share a material definition, but differ in the number of supported textures.",
+  "allOf": [
+    {
+      "if": {
+        "properties": { "assetType": { "const": "outfit" } }
+      },
+      "then": {
+        "allOf": [
+          { "$ref": "assetOutfit.schema.json" },
+          { "$ref": "assetOutfit.schema.json#/$defs/outfitTextureCount" }
+        ]
+      },
+      "$comment": "Outfit is the default asset type if no assetType is set in the data."
+    },
+    {
+      "if": {
+        "properties": { "assetType": { "const": "beard" } },
+        "required": ["assetType"]
+      },
+      "then": { "$ref": "assetBeard.schema.json" }
+    },
+    {
+      "if": {
+        "properties": { "assetType": { "const": "facewear" } },
+        "required": ["assetType"]
+      },
+      "then": {
+        "allOf": [
+          { "$ref": "assetFacewear.schema.json" },
+          {
+            "$ref": "commonTexture.schema.json#/$defs/dualMaterialTextureCount"
+          }
+        ]
+      }
+    },
+    {
+      "if": {
+        "properties": { "assetType": { "const": "glasses" } },
+        "required": ["assetType"]
+      },
+      "then": {
+        "allOf": [
+          { "$ref": "assetGlasses.schema.json" },
+          {
+            "$ref": "commonTexture.schema.json#/$defs/dualMaterialTextureCount"
+          }
+        ]
+      }
+    },
+    {
+      "if": {
+        "properties": { "assetType": { "const": "hair" } },
+        "required": ["assetType"]
+      },
+      "then": { "$ref": "assetHair.schema.json" }
+    },
+    {
+      "if": {
+        "properties": { "assetType": { "const": "headwear" } },
+        "required": ["assetType"]
+      },
+      "then": {
+        "allOf": [
+          { "$ref": "assetHeadwear.schema.json" },
+          {
+            "$ref": "commonTexture.schema.json#/$defs/dualMaterialTextureCount"
+          }
+        ]
+      }
+    },
+    {
+      "if": {
+        "properties": { "assetType": { "const": "nonCustomizableAvatar" } },
+        "required": ["assetType"]
+      },
+      "then": {
+        "allOf": [
+          { "$ref": "assetNonCustomizableAvatar.schema.json" },
+          {
+            "$ref": "assetNonCustomizableAvatar.schema.json#/$defs/nonCustomizableAvatarTextureCount"
+          }
+        ]
+      }
+    },
+    {
+      "if": {
+        "properties": { "assetType": { "const": "shirt" } },
+        "required": ["assetType"]
+      },
+      "then": {
+        "allOf": [
+          { "$ref": "assetShirt.schema.json" },
+          {
+            "$ref": "commonTexture.schema.json#/$defs/singleMaterialTextureCount"
+          }
+        ]
+      }
+    }
+  ],
+  "errorMessage": {
+    "type": "Validation data should be a JSON object.",
+    "required": {
+      "transforms": "Validation data should have a 'transforms' property."
+    },
+    "_": "Asset failed validation against its asset type ${0/assetType}."
+  }
+}

--- a/schemas/joints.schema.json
+++ b/schemas/joints.schema.json
@@ -1,0 +1,227 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "joints.schema.json",
+  "title": "Skeleton Joints",
+  "description": "Validation schema for common properties of skeleton hierarchies as mappings of joint names to their parent name.",
+  "type": "object",
+  "properties": {},
+  "$defs": {
+    "noSkeleton": {
+      "description": "Empty joint mapping. No skeleton present.",
+      "type": "object",
+      "properties": {},
+      "additionalProperties": false
+    },
+    "headwear": {
+      "description": "Headwear skeleton hierarchy.",
+      "type": "object",
+      "properties": {
+        "Spine": { "type": "string", "const": "Headwear_Rig" },
+        "Neck": { "type": "string", "const": "Spine" },
+        "Head": { "type": "string", "const": "Neck" }
+      },
+      "required": ["Spine", "Neck", "Head"],
+      "additionalProperties": {
+        "not": true,
+        "type": "object",
+        "errorMessage": "Found unsupported skeleton joint: ${0#}. Check the correct name."
+      },
+      "errorMessage": {
+        "required": {
+          "Spine": "Missing Spine joint.",
+          "Neck": "Missing Neck joint.",
+          "Head": "Missing Head joint."
+        },
+        "_": "Invalid skeleton definition."
+      }
+    },
+    "skeletonV2": {
+      "description": "Humanoid Ready Player Me skeleton hierarchy v2.",
+      "type": "object",
+      "properties": {
+        "Hips": { "type": "string", "const": "Armature" },
+        "Spine": { "type": "string", "const": "Hips" },
+        "Spine1": { "type": "string", "const": "Spine" },
+        "Spine2": { "type": "string", "const": "Spine1" },
+        "Neck": { "type": "string", "const": "Spine2" },
+        "Head": { "type": "string", "const": "Neck" },
+        "HeadTop_End": { "type": "string", "const": "Head" },
+        "LeftShoulder": { "type": "string", "const": "Spine2" },
+        "LeftArm": { "type": "string", "const": "LeftShoulder" },
+        "LeftForeArm": { "type": "string", "const": "LeftArm" },
+        "LeftHand": { "type": "string", "const": "LeftForeArm" },
+        "LeftHandThumb1": { "type": "string", "const": "LeftHand" },
+        "LeftHandThumb2": { "type": "string", "const": "LeftHandThumb1" },
+        "LeftHandThumb3": { "type": "string", "const": "LeftHandThumb2" },
+        "LeftHandThumb4": { "type": "string", "const": "LeftHandThumb3" },
+        "LeftHandIndex1": { "type": "string", "const": "LeftHand" },
+        "LeftHandIndex2": { "type": "string", "const": "LeftHandIndex1" },
+        "LeftHandIndex3": { "type": "string", "const": "LeftHandIndex2" },
+        "LeftHandIndex4": { "type": "string", "const": "LeftHandIndex3" },
+        "LeftHandMiddle1": { "type": "string", "const": "LeftHand" },
+        "LeftHandMiddle2": { "type": "string", "const": "LeftHandMiddle1" },
+        "LeftHandMiddle3": { "type": "string", "const": "LeftHandMiddle2" },
+        "LeftHandMiddle4": { "type": "string", "const": "LeftHandMiddle3" },
+        "LeftHandRing1": { "type": "string", "const": "LeftHand" },
+        "LeftHandRing2": { "type": "string", "const": "LeftHandRing1" },
+        "LeftHandRing3": { "type": "string", "const": "LeftHandRing2" },
+        "LeftHandRing4": { "type": "string", "const": "LeftHandRing3" },
+        "LeftHandPinky1": { "type": "string", "const": "LeftHand" },
+        "LeftHandPinky2": { "type": "string", "const": "LeftHandPinky1" },
+        "LeftHandPinky3": { "type": "string", "const": "LeftHandPinky2" },
+        "LeftHandPinky4": { "type": "string", "const": "LeftHandPinky3" },
+        "RightShoulder": { "type": "string", "const": "Spine2" },
+        "RightArm": { "type": "string", "const": "RightShoulder" },
+        "RightForeArm": { "type": "string", "const": "RightArm" },
+        "RightHand": { "type": "string", "const": "RightForeArm" },
+        "RightHandThumb1": { "type": "string", "const": "RightHand" },
+        "RightHandThumb2": { "type": "string", "const": "RightHandThumb1" },
+        "RightHandThumb3": { "type": "string", "const": "RightHandThumb2" },
+        "RightHandThumb4": { "type": "string", "const": "RightHandThumb3" },
+        "RightHandIndex1": { "type": "string", "const": "RightHand" },
+        "RightHandIndex2": { "type": "string", "const": "RightHandIndex1" },
+        "RightHandIndex3": { "type": "string", "const": "RightHandIndex2" },
+        "RightHandIndex4": { "type": "string", "const": "RightHandIndex3" },
+        "RightHandMiddle1": { "type": "string", "const": "RightHand" },
+        "RightHandMiddle2": { "type": "string", "const": "RightHandMiddle1" },
+        "RightHandMiddle3": { "type": "string", "const": "RightHandMiddle2" },
+        "RightHandMiddle4": { "type": "string", "const": "RightHandMiddle3" },
+        "RightHandRing1": { "type": "string", "const": "RightHand" },
+        "RightHandRing2": { "type": "string", "const": "RightHandRing1" },
+        "RightHandRing3": { "type": "string", "const": "RightHandRing2" },
+        "RightHandRing4": { "type": "string", "const": "RightHandRing3" },
+        "RightHandPinky1": { "type": "string", "const": "RightHand" },
+        "RightHandPinky2": { "type": "string", "const": "RightHandPinky1" },
+        "RightHandPinky3": { "type": "string", "const": "RightHandPinky2" },
+        "RightHandPinky4": { "type": "string", "const": "RightHandPinky3" },
+        "LeftUpLeg": { "type": "string", "const": "Hips" },
+        "LeftLeg": { "type": "string", "const": "LeftUpLeg" },
+        "LeftFoot": { "type": "string", "const": "LeftLeg" },
+        "LeftToeBase": { "type": "string", "const": "LeftFoot" },
+        "LeftToe_End": { "type": "string", "const": "LeftToeBase" },
+        "RightUpLeg": { "type": "string", "const": "Hips" },
+        "RightLeg": { "type": "string", "const": "RightUpLeg" },
+        "RightFoot": { "type": "string", "const": "RightLeg" },
+        "RightToeBase": { "type": "string", "const": "RightFoot" },
+        "RightToe_End": { "type": "string", "const": "RightToeBase" }
+      },
+      "required": [
+        "Hips",
+        "Spine",
+        "Spine1",
+        "Spine2",
+        "Neck",
+        "Head",
+        "HeadTop_End",
+        "LeftShoulder",
+        "LeftArm",
+        "LeftForeArm",
+        "LeftHand",
+        "LeftHandThumb1",
+        "LeftHandThumb2",
+        "LeftHandThumb3",
+        "LeftHandThumb4",
+        "LeftHandIndex1",
+        "LeftHandIndex2",
+        "LeftHandIndex3",
+        "LeftHandIndex4",
+        "LeftHandMiddle1",
+        "LeftHandMiddle2",
+        "LeftHandMiddle3",
+        "LeftHandMiddle4",
+        "LeftHandRing1",
+        "LeftHandRing2",
+        "LeftHandRing3",
+        "LeftHandRing4",
+        "LeftHandPinky1",
+        "LeftHandPinky2",
+        "LeftHandPinky3",
+        "LeftHandPinky4",
+        "RightShoulder",
+        "RightArm",
+        "RightForeArm",
+        "RightHand",
+        "RightHandThumb1",
+        "RightHandThumb2",
+        "RightHandThumb3",
+        "RightHandThumb4",
+        "RightHandIndex1",
+        "RightHandIndex2",
+        "RightHandIndex3",
+        "RightHandIndex4",
+        "RightHandMiddle1",
+        "RightHandMiddle2",
+        "RightHandMiddle3",
+        "RightHandMiddle4",
+        "RightHandRing1",
+        "RightHandRing2",
+        "RightHandRing3",
+        "RightHandRing4",
+        "RightHandPinky1",
+        "RightHandPinky2",
+        "RightHandPinky3",
+        "RightHandPinky4",
+        "LeftUpLeg",
+        "LeftLeg",
+        "LeftFoot",
+        "LeftToeBase",
+        "LeftToe_End",
+        "RightUpLeg",
+        "RightLeg",
+        "RightFoot",
+        "RightToeBase",
+        "RightToe_End"
+      ],
+      "$defs": {
+        "maxJoints": {
+          "description": "Maximum allowed number of joints in the skeleton.",
+          "$comment": "A workaround to extend the schema with additional joints, but only allow defined ones in this schema. Usage: allOf: [{ '$ref': '#/$defs/skeletonV2' }, { '$ref': '#/$defs/skeletonV2/$defs/maxJoints' }]",
+          "type": "object",
+          "minProperties": 65,
+          "maxProperties": 65,
+          "errorMessage": {
+            "minProperties": "Number of joints in the skeleton must be 65.",
+            "maxProperties": "Exceeded supported number of 65 joints in the skeleton."
+          }
+        }
+      },
+      "errorMessage": { "required": "Missing skeleton joints." }
+    },
+    "skeletonV2WithEyes": {
+      "$comment": "This schema extends the skeletonV2 schema. This is tricky when no extra joints are allowed in both, so we check for number of properties.",
+      "allOf": [
+        { "$ref": "#/$defs/skeletonV2" },
+        { "$ref": "#/$defs/skeletonV2WithEyes/$defs/maxJoints" },
+        {
+          "description": "Humanoid Ready Player Me skeleton hierarchy with eye joints v2.",
+          "type": "object",
+          "properties": {
+            "LeftEye": { "type": "string", "const": "Head" },
+            "RightEye": { "type": "string", "const": "Head" }
+          },
+          "required": ["LeftEye", "RightEye"],
+          "errorMessage": {
+            "required": {
+              "LeftEye": "Missing LeftEye joint.",
+              "RightEye": "Missing RightEye joint."
+            },
+            "maxProperties": "Found too many skeleton joints.",
+            "_": "Invalid skeleton definition."
+          }
+        }
+      ],
+      "$defs": {
+        "maxJoints": {
+          "description": "Maximum allowed number of joints in the skeleton.",
+          "type": "object",
+          "minProperties": 67,
+          "maxProperties": 67,
+          "errorMessage": {
+            "minProperties": "Number of joints in the skeleton must be 67.",
+            "maxProperties": "Exceeded supported number of 67 joints in the skeleton."
+          }
+        }
+      }
+    }
+  }
+}

--- a/schemas/materialNames.schema.json
+++ b/schemas/materialNames.schema.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "materialNames.schema.json",
+  "title": "Material Names",
+  "description": "Allowed names of materials for different asset types.",
+  "type": "object",
+  "properties": {
+    "beard": { "type": "string", "const": "Wolf3D_Beard", "errorMessage": "Material name should be 'Wolf3D_Beard'. Found ${0} instead." },
+    "facewear": { "type": "string", "const": "Wolf3D_Facewear", "errorMessage": "Material name should be 'Wolf3D_Facewear'. Found ${0} instead." },
+    "glasses": { "type": "string", "const": "Wolf3D_Glasses", "errorMessage": "Material name should be 'Wolf3D_Glasses'. Found ${0} instead." },
+    "hair": { "type": "string", "const": "Wolf3D_Hair", "errorMessage": "Material name should be 'Wolf3D_Hair'. Found ${0} instead." },
+    "halfbodyShirt": { "type": "string", "const": "Wolf3D_Shirt", "errorMessage": "Material name should be 'Wolf3D_Shirt'. Found ${0} instead." },
+    "head": { "type": "string", "const": "Wolf3D_Skin", "errorMessage": "Material name should be 'Wolf3D_Skin'. Found ${0} instead." },
+    "headwear": { "type": "string", "const": "Wolf3D_Headwear", "errorMessage": "Material name should be 'Wolf3D_Headwear'. Found ${0} instead." },
+    "modularBottom": { "type": "string", "const": "Wolf3D_Outfit_Bottom", "errorMessage": "Material name should be 'Wolf3D_Outfit_Bottom'. Found ${0} instead." },
+    "modularFootwear": { "type": "string", "const": "Wolf3D_Outfit_Footwear", "errorMessage": "Material name should be 'Wolf3D_Outfit_Footwear'. Found ${0} instead." },
+    "modularTop": { "type": "string", "const": "Wolf3D_Outfit_Top", "errorMessage": "Material name should be 'Wolf3D_Outfit_Top'. Found ${0} instead." },
+    "nonCustomizableAvatar": {
+      "enum": [
+        "Wolf3D_Body",
+        "Wolf3D_Eye",
+        "Wolf3D_Outfit_Bottom",
+        "Wolf3D_Outfit_Footwear",
+        "Wolf3D_Outfit_Top",
+        "Wolf3D_Skin",
+        "Wolf3D_Teeth"
+      ],
+      "errorMessage": "Material name should be one of 'Wolf3D_Body', 'Wolf3D_Eye', 'Wolf3D_Outfit_Bottom', 'Wolf3D_Outfit_Footwear', 'Wolf3D_Outfit_Top', 'Wolf3D_Skin', 'Wolf3D_Teeth'. Found ${0} instead."
+    },
+    "outfit": {
+      "enum": [
+        "Wolf3D_Body",
+        "Wolf3D_Outfit_Bottom",
+        "Wolf3D_Outfit_Footwear",
+        "Wolf3D_Outfit_Top"
+      ],
+      "errorMessage": "Material name should be one of 'Wolf3D_Body', 'Wolf3D_Outfit_Bottom', 'Wolf3D_Outfit_Footwear', 'Wolf3D_Outfit_Top'. Found ${0} instead."
+    }
+  }
+}

--- a/schemas/meshAttributes.schema.json
+++ b/schemas/meshAttributes.schema.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "meshAttributes.schema.json",
+  "title": "Mesh Attributes",
+  "description": "Data attributes for mesh vertices. Includes the vertex position, normal, tangent, texture coordinates, influencing joints, and skin weights.",
+  "type": "object",
+  "properties": {
+    "unskinned": {
+      "description": "Attributes for unskinned meshes. Optional tangents.",
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": ["NORMAL:f32", "POSITION:f32", "TEXCOORD_0:f32", "TANGENT:f32"],
+        "errorMessage": "Mesh ${2/name} error! Allowed attributes are: NORMAL, POSITION, TEXCOORD_0, TANGENT. Found ${0}."
+      },
+      "contains": {
+        "type": "string",
+        "pattern": "NORMAL:f32|POSITION:f32|TEXCOORD_0:f32",
+        "errorMessage": "Mesh ${2/name} requires at least 5 vertex attributes: position, normal, 1 UV set, joint influences, and weights. Found ${1/length} attributes: ${1}."
+      },
+      "minContains": 3,
+      "uniqueItems": true,
+      "errorMessage": "Mesh ${1/name} requires at least 5 vertex attributes: position, normal, 1 UV set, joint influences, and weights. Found ${0/length} attributes: ${0}."
+    },
+    "skinned": {
+      "description": "Attributes for skinned meshes. Optional tangents.",
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": [
+          "JOINTS_0:u8",
+          "NORMAL:f32",
+          "POSITION:f32",
+          "TEXCOORD_0:f32",
+          "TANGENT:f32",
+          "WEIGHTS_0:f32"
+        ],
+        "errorMessage": "Mesh ${2/name} error! Allowed attributes are: JOINTS_0, NORMAL, POSITION, TEXCOORD_0, TANGENT, WEIGHTS_0. Found ${0}."
+      },
+      "contains": {
+        "type": "string",
+        "pattern": "JOINTS_0:u8|NORMAL:f32|POSITION:f32|TEXCOORD_0:f32|WEIGHTS_0:f32",
+        "errorMessage": "Mesh ${2/name} requires at least 5 vertex attributes: position, normal, 1 UV set, joint influences, and weights. Found ${1/length} attributes: ${1}."
+      },
+      "minContains": 5,
+      "uniqueItems": true,
+      "errorMessage": "Mesh ${1/name} requires at least 5 vertex attributes: position, normal, 1 UV set, joint influences, and weights. Found ${0/length} attributes: ${0}."
+    }
+  }
+}

--- a/schemas/meshNames.schema.json
+++ b/schemas/meshNames.schema.json
@@ -1,0 +1,83 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "meshNames.schema.json",
+  "title": "Mesh Names",
+  "description": "Allowed names of meshes for different asset types.",
+  "type": "object",
+  "properties": {
+    "beard": {
+      "type": "string",
+      "const": "Wolf3D_Beard",
+      "errorMessage": "Mesh name should be 'Wolf3D_Beard'. Found ${0} instead."
+    },
+    "facewear": {
+      "type": "string",
+      "const": "Wolf3D_Facewear",
+      "errorMessage": "Mesh name should be 'Wolf3D_Facewear'. Found ${0} instead."
+    },
+    "glasses": {
+      "type": "string",
+      "const": "Wolf3D_Glasses",
+      "errorMessage": "Mesh name should be 'Wolf3D_Glasses'. Found ${0} instead."
+    },
+    "hair": {
+      "type": "string",
+      "const": "Wolf3D_Hair",
+      "errorMessage": "Mesh name should be 'Wolf3D_Hair'. Found ${0} instead."
+    },
+    "halfbodyShirt": {
+      "type": "string",
+      "const": "Wolf3D_Shirt",
+      "errorMessage": "Mesh name should be 'Wolf3D_Shirt'. Found ${0} instead."
+    },
+    "head": {
+      "type": "string",
+      "const": "Wolf3D_Head",
+      "errorMessage": "Mesh name should be 'Wolf3D_Head'. Found ${0} instead."
+    },
+    "headwear": {
+      "type": "string",
+      "const": "Wolf3D_Headwear",
+      "errorMessage": "Mesh name should be 'Wolf3D_Headwear'. Found ${0} instead."
+    },
+    "modularBottom": {
+      "type": "string",
+      "const": "Wolf3D_Outfit_Bottom",
+      "errorMessage": "Mesh name should be 'Wolf3D_Outfit_Bottom'. Found ${0} instead."
+    },
+    "modularFootwear": {
+      "type": "string",
+      "const": "Wolf3D_Outfit_Footwear",
+      "errorMessage": "Mesh name should be 'Wolf3D_Outfit_Footwear'. Found ${0} instead."
+    },
+    "modularTop": {
+      "type": "string",
+      "const": "Wolf3D_Outfit_Top",
+      "errorMessage": "Mesh name should be 'Wolf3D_Outfit_Top'. Found ${0} instead."
+    },
+    "nonCustomizableAvatar": {
+      "type": "string",
+      "enum": [
+        "EyeLeft",
+        "EyeRight",
+        "Wolf3D_Body_Custom",
+        "Wolf3D_Head_Custom",
+        "Wolf3D_Outfit_Bottom",
+        "Wolf3D_Outfit_Footwear",
+        "Wolf3D_Outfit_Top",
+        "Wolf3D_Teeth"
+      ],
+      "errorMessage": "Mesh name should be one of 'EyeLeft', 'EyeRight', 'Wolf3D_Body_Custom', 'Wolf3D_Head_Custom', 'Wolf3D_Outfit_Bottom', 'Wolf3D_Outfit_Footwear', 'Wolf3D_Outfit_Top', 'Wolf3D_Teeth'. Found ${0} instead."
+    },
+    "outfit": {
+      "type": "string",
+      "enum": [
+        "Wolf3D_Body",
+        "Wolf3D_Outfit_Bottom",
+        "Wolf3D_Outfit_Footwear",
+        "Wolf3D_Outfit_Top"
+      ],
+      "errorMessage": "Mesh name should be one of 'Wolf3D_Body', 'Wolf3D_Outfit_Bottom', 'Wolf3D_Outfit_Footwear', 'Wolf3D_Outfit_Top'. Found ${0} instead."
+    }
+  }
+}

--- a/schemas/meshTriangleCount.schema.json
+++ b/schemas/meshTriangleCount.schema.json
@@ -1,0 +1,121 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "meshTriangleCount.schema.json",
+  "title": "Triangle Count",
+  "description": "Triangle count budgets for meshes.",
+  "type": "object",
+  "properties": {
+    "beard": {
+      "type": "integer",
+      "maximum": 1000,
+      "errorMessage": {
+        "maximum": "Mesh ${1/name} exceeds triangle count budget. Allowed: 1000. Found: ${0}."
+      }
+    },
+    "body": {
+      "type": "integer",
+      "maximum": 14000,
+      "errorMessage": {
+        "maximum": "Mesh ${1/name} exceeds triangle count budget. Allowed: 14000. Found: ${0}."
+      }
+    },
+    "bodyCustom": {
+      "type": "integer",
+      "maximum": 14000,
+      "errorMessage": {
+        "maximum": "Mesh ${1/name} exceeds triangle count budget. Allowed: 14000. Found: ${0}."
+      }
+    },
+    "eyebrow": {
+      "type": "integer",
+      "maximum": 60,
+      "errorMessage": {
+        "maximum": "Mesh ${1/name} exceeds triangle count budget. Allowed: 60. Found: ${0}."
+      }
+    },
+    "eye": {
+      "type": "integer",
+      "maximum": 60,
+      "errorMessage": {
+        "maximum": "Mesh ${1/name} exceeds triangle count budget. Allowed: 60. Found: ${0}."
+      }
+    },
+    "facewear": {
+      "type": "integer",
+      "maximum": 900,
+      "errorMessage": {
+        "maximum": "Mesh ${1/name} exceeds triangle count budget. Allowed: 900. Found: ${0}."
+      }
+    },
+    "glasses": {
+      "type": "integer",
+      "maximum": 1000,
+      "errorMessage": {
+        "maximum": "Mesh ${1/name} exceeds triangle count budget. Allowed: 1000. Found: ${0}."
+      }
+    },
+    "hair": {
+      "type": "integer",
+      "maximum": 3000,
+      "errorMessage": {
+        "maximum": "Mesh ${1/name} exceeds triangle count budget. Allowed: 3000. Found: ${0}."
+      }
+    },
+    "head": {
+      "type": "integer",
+      "maximum": 4574,
+      "errorMessage": {
+        "maximum": "Mesh ${1/name} exceeds triangle count budget. Allowed: 4574. Found: ${0}."
+      }
+    },
+    "headCustom": {
+      "type": "integer",
+      "maximum": 6000,
+      "errorMessage": {
+        "maximum": "Mesh ${1/name} exceeds triangle count budget. Allowed: 6000. Found: ${0}."
+      }
+    },
+    "headwear": {
+      "type": "integer",
+      "maximum": 2500,
+      "errorMessage": {
+        "maximum": "Mesh ${1/name} exceeds triangle count budget. Allowed: 2500. Found: ${0}."
+      }
+    },
+    "outfitBottom": {
+      "type": "integer",
+      "maximum": 5000,
+      "errorMessage": {
+        "maximum": "Mesh ${1/name} exceeds triangle count budget. Allowed: 5000. Found: ${0}."
+      }
+    },
+    "outfitTop": {
+      "type": "integer",
+      "maximum": 6000,
+      "errorMessage": {
+        "maximum": "Mesh ${1/name} exceeds triangle count budget. Allowed: 6000. Found: ${0}."
+      }
+    },
+    "outfitFootwear": {
+      "type": "integer",
+      "maximum": 2000,
+      "errorMessage": {
+        "maximum": "Mesh ${1/name} exceeds triangle count budget. Allowed: 2000. Found: ${0}."
+      }
+    },
+    "halfbodyShirt": {
+      "type": "integer",
+      "maximum": 1000,
+      "errorMessage": {
+        "maximum": "Mesh ${1/name} exceeds triangle count budget. Allowed: 1000. Found: ${0}."
+      }
+    },
+    "teeth": {
+      "type": "integer",
+      "maximum": 1000,
+      "errorMessage": {
+        "maximum": "Mesh ${1/name} exceeds triangle count budget. Allowed: 1000. Found: ${0}."
+      }
+    }
+  }
+}

--- a/schemas/scene.schema.json
+++ b/schemas/scene.schema.json
@@ -1,0 +1,168 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "scene.schema.json",
+  "title": "Scene",
+  "description": "Scenes of the gltf file.",
+  "type": "object",
+  "$defs": {
+    "hasDefaultScene": {
+      "description": "Whether the gltf file has a default scene.",
+      "type": "boolean",
+      "const": true,
+      "errorMessage": "The gltf file should have a default scene."
+    },
+    "singleMeshScene": {
+      "type": "object",
+      "properties": {
+        "hasDefaultScene": { "$ref": "#/$defs/hasDefaultScene" },
+        "properties": {
+          "$comment": "inspect() creates a 'properties' object. Do not confuse with the 'properties' keyword.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": { "description": "Name of the scene.", "type": "string" },
+              "rootName": {
+                "description": "Name of the root node in the scene.",
+                "type": "string",
+                "const": { "$data": "/meshes/properties/0/name" },
+                "errorMessage": "The mesh should be the root node. Mesh name is ${/meshes/properties/0/name}. Found root ${0} instead."
+              }
+            },
+            "allOf": [{ "$ref": "#/$defs/headBbox" }],
+            "required": ["rootName"],
+            "errorMessage": {
+              "required": {
+                "rootName": "Missing root node property in the scene ${0/name}."
+              }
+            }
+          },
+          "minItems": 1,
+          "maxItems": 1,
+          "errorMessage": {
+            "minItems": "There must be one scene. Found ${0/length}.",
+            "maxItems": "There must be only one scene. Found ${0/length}."
+          }
+        }
+      },
+      "required": ["hasDefaultScene", "properties"]
+    },
+    "fullbodyOutfitScene": {
+      "type": "object",
+      "properties": {
+        "hasDefaultScene": { "$ref": "#/$defs/hasDefaultScene" },
+        "properties": {
+          "$comment": "inspect() creates a 'properties' object. Do not confuse with the 'properties' keyword.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": { "description": "Name of the scene.", "type": "string" },
+              "rootName": {
+                "description": "Name of the root node in the scene.",
+                "type": "string",
+                "const": "Armature",
+                "errorMessage": "The 'Armature' should be the root node. Found root ${0} instead."
+              }
+            },
+            "allOf": [{ "$ref": "#/$defs/bodyBbox" }]
+          },
+          "minItems": 1,
+          "maxItems": 1,
+          "errorMessage": {
+            "minItems": "There must be one scene. Found ${0/length}.",
+            "maxItems": "There must be only one scene. Found ${0/length}."
+          }
+        }
+      },
+      "required": ["hasDefaultScene", "properties"]
+    },
+    "headBbox": {
+      "type": "object",
+      "properties": {
+        "bboxMin": {
+          "type": "array",
+          "items": { "type": "number" },
+          "minItems": 3,
+          "maxItems": 3,
+          "errorMessage": "Minimum bounds (${0#}) must be an array of 3 numbers (x, y, z). Found ${0}."
+        },
+        "bboxMax": {
+          "type": "array",
+          "items": {
+            "type": "number",
+            "maximum": 1.0,
+            "errorMessage": {
+              "maximum": "The bounding box maximum (${1#}) is 1.0. Found maximum bounds: ${1}. Error at index ${0#}.",
+              "_": "Bounding box error"
+            }
+          },
+          "minItems": 3,
+          "maxItems": 3,
+          "errorMessage": "Maximum bounds (${0#}) must be an array of 3 numbers (x, y, z). Found ${0}."
+        }
+      },
+      "required": ["bboxMin", "bboxMax"]
+    },
+    "bodyBbox": {
+      "type": "object",
+      "properties": {
+        "bboxMin": {
+          "type": "array",
+          "prefixItems": [
+            {
+              "type": "number",
+              "minimum": -1.0,
+              "maximum": 0.0,
+              "errorMessage": "Bounding Box X minimum for body area must be between -1.0 and 0.0. Found ${0} and index ${0#}"
+            },
+            {
+              "type": "number",
+              "minimum": -0.1,
+              "maximum": 0.5,
+              "errorMessage": "Bounding Box Y minimum for body area must be between -0.1 and 0.5. Found ${0} and index ${0#}"
+            },
+            {
+              "type": "number",
+              "minimum": -1.0,
+              "maximum": 0.0,
+              "errorMessage": "Bounding Box Z minimum for body area must be between -1.0 and 0.0. Found ${0} and index ${0#}"
+            }
+          ],
+          "items": false,
+          "minItems": 3,
+          "maxItems": 3,
+          "errorMessage": "Minimum bounds (${0#}) must be an array of 3 numbers (x, y, z). Found ${0}."
+        },
+        "bboxMax": {
+          "type": "array",
+          "prefixItems": [
+            {
+              "type": "number",
+              "minimum": 0.0,
+              "maximum": 1.0,
+              "errorMessage": "Bounding Box Z maximum for body area must be between 0.0 and 1.0. Found ${0} and index ${0#}"
+            },
+            {
+              "type": "number",
+              "minimum": 0.0,
+              "maximum": 3.0,
+              "errorMessage": "Bounding Box Z maximum for body area must be between 0.0 and 3.0. Found ${0} and index ${0#}"
+            },
+            {
+              "type": "number",
+              "minimum": 0.0,
+              "maximum": 1.0,
+              "errorMessage": "Bounding Box Z maximum for body area must be between 0.0 and 1.0. Found ${0} and index ${0#}"
+            }
+          ],
+          "items": false,
+          "minItems": 3,
+          "maxItems": 3,
+          "errorMessage": "Maximum bounds (${0#}) must be an array of 3 numbers (x, y, z). Found ${0}."
+        }
+      },
+      "required": ["bboxMin", "bboxMax"]
+    }
+  }
+}


### PR DESCRIPTION
This adds JSON schemas for validating data abstractions that are collected from binary glTF files using gltf-transform and gltf-validator.

They are meant to be validated using ajv, and ajv-errors for providing custom error messages.