### PR TITLE
fix!: support 'Armature' for facewear and headwear

### DIFF
--- a/schemas/assetFacewear.schema.json
+++ b/schemas/assetFacewear.schema.json
@@ -20,7 +20,14 @@
                 "$ref": "meshNames.schema.json#/properties/facewear"
               },
               "attributes": {
-                "$ref": "meshAttributes.schema.json#/properties/unskinned"
+                "oneOf": [
+                  {
+                    "$ref": "meshAttributes.schema.json#/properties/skinned"
+                  },
+                  {
+                    "$ref": "meshAttributes.schema.json#/properties/unskinned"
+                  }
+                ]
               },
               "glPrimitives": {
                 "$ref": "meshTriangleCount.schema.json#/properties/facewear"

--- a/schemas/assetHeadwear.schema.json
+++ b/schemas/assetHeadwear.schema.json
@@ -5,42 +5,7 @@
   "description": "A Ready Player Me glTF binary validation schema for headwear.",
   "type": "object",
   "properties": {
-    "scenes": {
-      "type": "object",
-      "properties": {
-        "properties": {
-          "$comment": "inspect() creates a 'properties' object. Do not confuse with the 'properties' keyword.",
-          "type": "array",
-          "items": {
-            "type": "object",
-            "properties": {
-              "name": { "description": "Name of the scene.", "type": "string" },
-              "rootName": {
-                "description": "Name of the root node in the scene.",
-                "oneOf": [
-                  { "$ref": "meshNames.schema.json#/properties/headwear" },
-                  { "type": "string", "const": "Headwear_Rig" }
-                ],
-                "errorMessage": "The root node should either be an unskinned mesh, or a skeleton named 'Headwear_Rig'. Mesh name is ${/meshes/properties/0/name}. Found root ${0} instead."
-              }
-            },
-            "allOf": [{ "$ref": "scene.schema.json#/$defs/headBbox" }],
-            "required": ["rootName"],
-            "errorMessage": {
-              "required": {
-                "rootName": "Missing root node property in the scene ${0/name}."
-              }
-            }
-          },
-          "minItems": 1,
-          "maxItems": 1,
-          "errorMessage": {
-            "minItems": "There must be exactly one scene.",
-            "maxItems": "There must be only one scene."
-          }
-        }
-      }
-    },
+    "scenes": { "$ref": "scene.schema.json#/$defs/singleMeshScene" },
     "meshes": {
       "type": "object",
       "properties": {

--- a/schemas/scene.schema.json
+++ b/schemas/scene.schema.json
@@ -25,8 +25,16 @@
               "rootName": {
                 "description": "Name of the root node in the scene.",
                 "type": "string",
-                "const": { "$data": "/meshes/properties/0/name" },
-                "errorMessage": "The mesh should be the root node. Mesh name is ${/meshes/properties/0/name}. Found root ${0} instead."
+                "if": {
+                  "const": { "$data": "/meshes/properties/0/name" }
+                },
+                "then": {
+                  "const": { "$data": "/meshes/properties/0/name" }
+                },
+                "else": {
+                  "const": "Armature"
+                },
+                "errorMessage": "The root node should either be the mesh, or a skeleton named 'Armature' if the mesh is skinned. Mesh name is ${/meshes/properties/0/name}. Found root ${0} instead."
               }
             },
             "allOf": [{ "$ref": "#/$defs/headBbox" }],


### PR DESCRIPTION
Facewear was missing support for skinned meshes.
An oversight in the avatar API necessitates the skeleton to be named "Armature". It was "Headwear_Rig" and "Facewear_Rig" before.
Now it's constistent with outfit skeletons.