### PR TITLE
feat(TECHART-132): any-sided clothing materials

### DIFF
--- a/schemas/assetNonCustomizableAvatar.schema.json
+++ b/schemas/assetNonCustomizableAvatar.schema.json
@@ -172,7 +172,7 @@
                 "$ref": "commonMaterial.schema.json#/$defs/allTextureChannels"
               },
               "doubleSided": {
-                "$ref": "commonMaterial.schema.json#/$defs/singleSided"
+                "$ref": "commonMaterial.schema.json#/$defs/anySided"
               },
               "alphaMode": {
                 "$ref": "commonMaterial.schema.json#/$defs/opaqueAlphaMode"

--- a/schemas/assetOutfit.schema.json
+++ b/schemas/assetOutfit.schema.json
@@ -129,9 +129,6 @@
               "textures": {
                 "description": "Textures used by the outfit materials. The 'Wolf3D_Body' material uses only the 'normalTexture'. All other materials can use all channels."
               },
-              "doubleSided": {
-                "$ref": "commonMaterial.schema.json#/$defs/singleSided"
-              },
               "alphaMode": {
                 "$ref": "commonMaterial.schema.json#/$defs/opaqueAlphaMode"
               }
@@ -150,6 +147,9 @@
                   "properties": {
                     "textures": {
                       "$ref": "commonMaterial.schema.json#/$defs/normalOnlyTextureChannels"
+                    },
+                    "doubleSided": {
+                      "$ref": "commonMaterial.schema.json#/$defs/singleSided"
                     }
                   }
                 },
@@ -157,6 +157,9 @@
                   "properties": {
                     "textures": {
                       "$ref": "commonMaterial.schema.json#/$defs/allTextureChannels"
+                    },
+                    "doubleSided": {
+                      "$ref": "commonMaterial.schema.json#/$defs/anySided"
                     }
                   }
                 }


### PR DESCRIPTION
Allow single and double sided materials.
For fullbody outfits, the Wolf3D_Body material needs to be single-sided.

All non-customizable avatar materials support single- or double-sidedness.