### PR TITLE
feat: Generate JSON schemas from Python data models [TECHART-244]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -138,6 +138,175 @@ dist
 # SvelteKit build / generate output
 .svelte-kit
 
+### Python ###
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/#use-with-ide
+.pdm.toml
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/
+
+### Python Patch ###
+# Poetry local configuration file - https://python-poetry.org/docs/configuration/#local-configuration
+poetry.toml
+
+# ruff
+.ruff_cache/
+
+# LSP config files
+pyrightconfig.json
+
 ### PyCharm ###
 # Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
 # Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
@@ -218,38 +387,13 @@ fabric.properties
 .idea/caches/build_file_checksums.ser
 
 ### PyCharm Patch ###
-# Comment Reason: https://github.com/joeblau/gitignore.io/issues/186#issuecomment-215987721
+# Ignore everything but code style settings and run configurations
+# that are supposed to be shared within teams.
 
-# *.iml
-# modules.xml
-# .idea/misc.xml
-# *.ipr
+.idea/*
 
-# Sonarlint plugin
-# https://plugins.jetbrains.com/plugin/7973-sonarlint
-.idea/**/sonarlint/
-
-# SonarQube Plugin
-# https://plugins.jetbrains.com/plugin/7238-sonarqube-community-plugin
-.idea/**/sonarIssues.xml
-
-# Markdown Navigator plugin
-# https://plugins.jetbrains.com/plugin/7896-markdown-navigator-enhanced
-.idea/**/markdown-navigator.xml
-.idea/**/markdown-navigator-enh.xml
-.idea/**/markdown-navigator/
-
-# Cache file creation bug
-# See https://youtrack.jetbrains.com/issue/JBR-2257
-.idea/$CACHE_FILE$
-
-# CodeStream plugin
-# https://plugins.jetbrains.com/plugin/12206-codestream
-.idea/codestream.xml
-
-# Azure Toolkit for IntelliJ plugin
-# https://plugins.jetbrains.com/plugin/8053-azure-toolkit-for-intellij
-.idea/**/azureSettings.xml
+!.idea/codeStyles
+!.idea/runConfigurations
 
 ### VisualStudioCode ###
 .vscode/*
@@ -295,3 +439,51 @@ $RECYCLE.BIN/
 
 # Windows shortcuts
 *.lnk
+
+### Linux ###
+*~
+
+# temporary files which can be created if a process still has a handle open of a deleted file
+.fuse_hidden*
+
+# KDE directory preferences
+.directory
+
+# Linux trash folder which might appear on any partition or disk
+.Trash-*
+
+# .nfs files are created when an open file is removed but is still being accessed
+.nfs*
+
+### macOS ###
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+### macOS Patch ###
+# iCloud generated files
+*.icloud

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023-present Ready Player Me <info@readyplayer.me>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -152,6 +152,25 @@ ban-relative-imports = "all"
 # Tests can use magic values, assertions, and relative imports
 "tests/**/*" = ["PLR2004", "S101", "TID252"]
 
+[tool.mypy]
+plugins = ["pydantic.mypy"]
+
+follow_imports = "silent"
+warn_redundant_casts = true
+warn_unused_ignores = true
+disallow_any_generics = true
+check_untyped_defs = true
+no_implicit_reexport = true
+
+# for strict mypy:
+disallow_untyped_defs = false
+
+[tool.pydantic-mypy]
+init_forbid_extra = true
+init_typed = true
+warn_required_dynamic_aliases = true
+warn_untyped_fields = true
+
 [tool.coverage.run]
 source_pkgs = ["readyplayerme/asset_validation_schemas", "tests"]
 branch = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,172 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "readyplayerme-asset-validation-schemas"
+dynamic = ["version"]
+description = 'Data models that are used to check data gathered from assets for compatibility with the Ready Player Me avatar platform.'
+readme = "README.md"
+requires-python = ">=3.10"
+license = "MIT"
+keywords = ["gltf", "3D", "json", "schema", "validation"]
+authors = [
+  { name = "Ready Player Me", email = "info@readyplayer.me" },
+]
+maintainers = [
+  { name = "Olaf Haag", email = "olaf@readyplayer.me" },
+]
+classifiers = [
+  "Development Status :: 4 - Beta",
+  "Programming Language :: Python",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: Implementation :: CPython",
+  "Programming Language :: Python :: Implementation :: PyPy",
+]
+dependencies = [
+  "pydantic"
+]
+
+[project.optional-dependencies]
+tests = [
+  "pytest",
+]
+dev = [
+  "readyplayerme-asset-validation-schemas[tests]",
+  "pre-commit",
+]
+
+[project.urls]
+Documentation = "https://github.com/wolfprint3d/content-validation-schemas#readme"
+Issues = "https://github.com/wolfprint3d/content-validation-schemas/issues"
+Source = "https://github.com/wolfprint3d/content-validation-schemas"
+
+[tool.hatch.version]
+path = "src/readyplayerme/asset_validation_schemas/__about__.py"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/readyplayerme"]
+
+[tool.hatch.envs.default]
+dependencies = [
+  "coverage[toml]>=6.5",
+  "pytest",
+]
+
+[tool.hatch.envs.default.scripts]
+test = "pytest {args:tests}"
+test-cov = "coverage run -m pytest {args:tests}"
+cov-report = [
+  "- coverage combine",
+  "coverage report",
+]
+cov = [
+  "test-cov",
+  "cov-report",
+]
+
+[[tool.hatch.envs.all.matrix]]
+python = ["3.10", "3.11"]
+
+[tool.hatch.envs.lint]
+detached = true
+dependencies = [
+  "black>=23.3.0",
+  "mypy>=1.3.0",
+  "ruff>=0.0.275",
+]
+[tool.hatch.envs.lint.scripts]
+typing = "mypy --install-types --non-interactive {args:src/readyplayerme/asset_validation_schemas tests}"
+style = [
+  "ruff {args:.}",
+  "black --check --diff {args:.}",
+]
+fmt = [
+  "black {args:.}",
+  "ruff --fix {args:.}",
+  "style",
+]
+all = [
+  "style",
+  "typing",
+]
+
+[tool.black]
+target-version = ["py311"]
+line-length = 120
+skip-string-normalization = true
+
+[tool.ruff]
+target-version = "py311"
+line-length = 120
+select = [
+  "A",
+  "ARG",
+  "B",
+  "C",
+  "DTZ",
+  "E",
+  "EM",
+  "F",
+  "FBT",
+  "I",
+  "ICN",
+  "ISC",
+  "N",
+  "PLC",
+  "PLE",
+  "PLR",
+  "PLW",
+  "Q",
+  "RUF",
+  "S",
+  "T",
+  "TID",
+  "UP",
+  "W",
+  "YTT",
+]
+ignore = [
+  # Allow non-abstract empty methods in abstract base classes
+  "B027",
+  # Allow boolean positional values in function calls, like `dict.get(... True)`
+  "FBT003",
+  # Ignore checks for possible passwords
+  "S105", "S106", "S107",
+  # Ignore complexity
+  "C901", "PLR0911", "PLR0912", "PLR0913", "PLR0915",
+]
+unfixable = [
+  # Don't touch unused imports
+  "F401",
+]
+
+[tool.ruff.isort]
+known-first-party = ["readyplayerme"]
+
+[tool.ruff.flake8-tidy-imports]
+ban-relative-imports = "all"
+
+[tool.ruff.per-file-ignores]
+# Tests can use magic values, assertions, and relative imports
+"tests/**/*" = ["PLR2004", "S101", "TID252"]
+
+[tool.coverage.run]
+source_pkgs = ["readyplayerme/asset_validation_schemas", "tests"]
+branch = true
+parallel = true
+omit = [
+  "src/readyplayerme/asset_validation_schemas/__about__.py",
+]
+
+[tool.coverage.paths]
+readyplayerme_content_validation_schemas = ["src/readyplayerme/asset_validation_schemas", "*/content-validation-schemas/src/readyplayerme/asset_validation_schemas"]
+tests = ["tests", "*/content-validation-schemas/tests"]
+
+[tool.coverage.report]
+exclude_lines = [
+  "no cov",
+  "if __name__ == .__main__.:",
+  "if TYPE_CHECKING:",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,7 +95,7 @@ all = [
 [tool.black]
 target-version = ["py311"]
 line-length = 120
-skip-string-normalization = true
+skip-string-normalization = false
 
 [tool.ruff]
 target-version = "py311"

--- a/src/readyplayerme/asset_validation_schemas/__about__.py
+++ b/src/readyplayerme/asset_validation_schemas/__about__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: 2023-present Ready Player Me <info@readyplayer.me>
+#
+# SPDX-License-Identifier: MIT
+__version__ = "0.0.1"

--- a/src/readyplayerme/asset_validation_schemas/basemodel.py
+++ b/src/readyplayerme/asset_validation_schemas/basemodel.py
@@ -1,0 +1,30 @@
+from typing import Any
+
+from pydantic import BaseConfig, Extra
+from pydantic import BaseModel as PydanticBaseModel
+
+
+class SchemaConfig(BaseConfig):
+    extra = Extra.forbid
+    validate_assignment = True
+    validate_all = True
+    anystr_strip_whitespace = True
+
+    @staticmethod
+    def schema_extra(schema: dict[str, Any], model: type["PydanticBaseModel"]) -> None:
+        # Add metaschema and id.
+        schema |= {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            # Get the "outer" class name with a lower case first letter.
+            "$id": f"{(name := model.__name__)[0].lower() + name[1:]}.schema.json",
+        }
+        # Remove "title" from properties.
+        for prop in schema.get("properties", {}).values():
+            prop.pop("title", None)
+
+
+class BaseModel(PydanticBaseModel):
+    """Global base class for all models."""
+
+    class Config(SchemaConfig):
+        ...

--- a/src/readyplayerme/asset_validation_schemas/mesh_triangle_count.py
+++ b/src/readyplayerme/asset_validation_schemas/mesh_triangle_count.py
@@ -1,0 +1,82 @@
+from typing import Any, ClassVar
+
+from pydantic import BaseModel as PydanticBaseModel
+from pydantic import (
+    ValidationError,
+    conint,
+    create_model,
+)
+
+from readyplayerme.asset_validation_schemas.basemodel import SchemaConfig
+
+ERROR_CODE = "TRIANGLE_COUNT"
+
+# Triangle budgets could be set via config.
+limits = {
+    "beard": 1000,
+    "body": 14000,
+    "body_custom": 14000,
+    "eyebrow": 60,
+    "eye": 60,
+    "facewear": 900,
+    "glasses": 1000,
+    "hair": 3000,
+    "head": 4574,
+    "headCustom": 6000,
+    "headwear": 2500,
+    "outfitBottom": 5000,
+    "outfitTop": 6000,
+    "outfitFootwear": 2000,
+    "halfbodyShirt": 1000,
+    "teeth": 1000,
+}
+
+
+def get_tricount_field_definitions(limits: dict[str, int]) -> Any:
+    """Turn simple integer limits into a dict of constrained positive integer field types."""
+    return {field_name: (conint(gt=0, le=limit), None) for field_name, limit in limits.items()}
+
+
+class TriCountConfig(SchemaConfig):
+    """Triangle count schema title and error messages."""
+
+    title = "Triangle Count"
+    error_msg_templates: ClassVar[dict[str, str]] = {
+        e: f"{ERROR_CODE} " + msg
+        for e, msg in {
+            "value_error.number.not_gt": "Mesh must have at least 1 triangle.",
+            "value_error.number.not_le": "Mesh exceeds triangle count budget. Allowed: {limit_value}.",
+            "value_error.extra": "Invalid extra mesh.",
+        }.items()
+    }
+
+    @classmethod  # As a staticmethod, TypeError is raised with super().schema_extra args. Works with classmethod.
+    def schema_extra(cls, schema: dict[str, Any], model: type["PydanticBaseModel"]) -> None:
+        super().schema_extra(schema, model)
+        # Add custom ajv-error messages to the schema.
+        for prop in schema.get("properties", {}).values():
+            prop["errorMessage"] = {
+                "exclusiveMinimum": "Mesh ${1/name} must have at least 1 triangle.",
+                "maximum": "Mesh ${1/name} exceeds triangle count budget. Allowed: %d. Found: ${0}." % prop["maximum"],
+            }
+
+
+# Dynamically create the model with the tri-count limits we defined earlier.
+MeshTriangleCountModel: type[PydanticBaseModel] = create_model(
+    "MeshTriangleCount",
+    __config__=TriCountConfig,
+    # Populate the fields.
+    **get_tricount_field_definitions(limits),
+)
+
+
+if __name__ == "__main__":
+    # Convert model to JSON schema.
+    print(MeshTriangleCountModel.schema_json(indent=2))
+
+    # Example of validation in Python.
+    try:
+        # Multiple checks at once. Test non-existent field as well.
+        MeshTriangleCountModel(outfitBottom=6000, outfitTop=0, outfitFootwear=1000, foo=10)
+    except ValidationError as error:
+        print("\nValidation Errors:\n", error)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: 2023-present Ready Player Me <info@readyplayer.me>
+#
+# SPDX-License-Identifier: MIT


### PR DESCRIPTION
This PR is a proof of concept to generate the JSON schemas for asset validation from Python data models using [pydantic](https://docs.pydantic.dev/).

Its goal is to have 1 source of truth that can be either used directly in Python or be exported to JSON schemas for consumption by other services.
It should theoretically even be possible to read compatible json instances generated by other services and validate them against the Python data model.

Checklist:
- [ ] all schemas converted to models
- [ ] unit tests
- [ ] functional tests
- [ ] github action
- [ ] docs
