### PR TITLE
feat(schema): hero avatars

### DIFF
--- a/schemas/assetHeroAvatar.schema.json
+++ b/schemas/assetHeroAvatar.schema.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "assetNonCustomizableAvatar.schema.json",
-  "title": "Non-Customizable Avatar Asset",
-  "description": "A Ready Player Me glTF binary validation schema for a non-Customizable avatar.",
+  "$id": "assetHeroAvatar.schema.json",
+  "title": "Hero Avatar Asset",
+  "description": "A Ready Player Me glTF binary validation schema for a hero avatar.",
   "type": "object",
   "properties": {
     "scenes": { "$ref": "scene.schema.json#/$defs/fullbodyOutfitScene" },
@@ -14,8 +14,8 @@
           "minimum": 1,
           "maximum": 30000,
           "errorMessage": {
-            "minimum": "Too few triangles! Non-customizable avatars must have at least 1 triangle.",
-            "maximum": "Too many triangles (${0})! Non-customizable avatars must have no more than a total of 30,000 triangles."
+            "minimum": "Too few triangles! Hero avatars must have at least 1 triangle.",
+            "maximum": "Too many triangles (${0})! Hero avatars must have no more than a total of 30,000 triangles."
           }
         },
         "properties": {
@@ -26,7 +26,7 @@
             "properties": {
               "name": {
                 "description": "Name of the mesh.",
-                "$ref": "meshNames.schema.json#/properties/nonCustomizableAvatar"
+                "$ref": "meshNames.schema.json#/properties/heroAvatar"
               },
               "attributes": {
                 "$ref": "meshAttributes.schema.json#/properties/skinned"
@@ -52,7 +52,10 @@
               {
                 "if": {
                   "properties": {
-                    "name": { "type": "string", "enum": ["EyeLeft", "EyeRight"] }
+                    "name": {
+                      "type": "string",
+                      "enum": ["EyeLeft", "EyeRight"]
+                    }
                   }
                 },
                 "then": {
@@ -132,6 +135,76 @@
                     }
                   }
                 }
+              },
+              {
+                "if": {
+                  "properties": {
+                    "name": { "const": "Wolf3D_Beard" }
+                  }
+                },
+                "then": {
+                  "properties": {
+                    "glPrimitives": {
+                      "$ref": "meshTriangleCount.schema.json#/properties/beard"
+                    }
+                  }
+                }
+              },
+              {
+                "if": {
+                  "properties": {
+                    "name": { "const": "Wolf3D_Facewear" }
+                  }
+                },
+                "then": {
+                  "properties": {
+                    "glPrimitives": {
+                      "$ref": "meshTriangleCount.schema.json#/properties/facewear"
+                    }
+                  }
+                }
+              },
+              {
+                "if": {
+                  "properties": {
+                    "name": { "const": "Wolf3D_Glasses" }
+                  }
+                },
+                "then": {
+                  "properties": {
+                    "glPrimitives": {
+                      "$ref": "meshTriangleCount.schema.json#/properties/glasses"
+                    }
+                  }
+                }
+              },
+              {
+                "if": {
+                  "properties": {
+                    "name": { "const": "Wolf3D_Hair" }
+                  }
+                },
+                "then": {
+                  "properties": {
+                    "glPrimitives": {
+                      "$ref": "meshTriangleCount.schema.json#/properties/hair"
+                    }
+                  }
+                }
+              },
+              {
+                "if": {
+                  "properties": {
+                    "name": { "const": "Wolf3D_Headwear" }
+                  }
+                },
+                "then": {
+                  "properties": {
+                    "glPrimitives": {
+                      "$ref": "meshTriangleCount.schema.json#/properties/headwear"
+                    }
+                  }
+                }
               }
             ],
             "required": [
@@ -147,10 +220,10 @@
             ]
           },
           "minItems": 1,
-          "maxItems": 8,
+          "maxItems": 13,
           "errorMessage": {
-            "minItems": "Missing mesh! Non-customizable avatars must have at least 1 mesh.",
-            "maxItems": "Too many meshes! Non-customizable avatars must have no more than 8 meshes."
+            "minItems": "Missing mesh! Hero avatars must have at least 1 mesh.",
+            "maxItems": "Too many meshes! Hero avatars must have no more than 13 meshes."
           }
         }
       }
@@ -166,7 +239,7 @@
             "properties": {
               "name": {
                 "description": "Name of the material.",
-                "$ref": "materialNames.schema.json#/properties/nonCustomizableAvatar"
+                "$ref": "materialNames.schema.json#/properties/heroAvatar"
               },
               "textures": {
                 "$ref": "commonMaterial.schema.json#/$defs/allTextureChannels"
@@ -175,12 +248,20 @@
                 "$ref": "commonMaterial.schema.json#/$defs/anySided"
               },
               "alphaMode": {
-                "$ref": "commonMaterial.schema.json#/$defs/opaqueAlphaMode"
+                "if": {
+                  "properties": {
+                    "name": { "const": "Wolf3D_Glasses" }
+                  }
+                },
+                "then": {
+                  "$ref": "commonMaterial.schema.json#/$defs/anyAlphaMode"
+                },
+                "else": {
+                  "$ref": "commonMaterial.schema.json#/$defs/opaqueAlphaMode"
+                }
               }
             },
-            "allOf": [
-              { "$ref": "commonMaterial.schema.json" }
-            ],
+            "allOf": [{ "$ref": "commonMaterial.schema.json" }],
             "required": [
               "name",
               "instances",
@@ -191,37 +272,17 @@
           },
           "uniqueItems": true,
           "minItems": 1,
-          "maxItems": 7,
+          "maxItems": 12,
           "errorMessage": {
             "minItems": "Missing material! This avatar must have at least 1 material. Found ${/materials/properties/length}.",
-            "maxItems": "Too many materials! This avatar only supports up to 7 materials (eyes share a material). Found ${/materials/properties/length}."
+            "maxItems": "Too many materials! This avatar only supports up to 12 materials (eyes share a material). Found ${/materials/properties/length}."
           }
         }
       }
     },
     "textures": { "$ref": "commonTexture.schema.json#/$defs/fullPBR" },
     "animations": { "$ref": "animation.schema.json#/properties/noAnimation" },
-    "joints" : { "$ref": "joints.schema.json#/$defs/skeletonV2WithEyes" }
+    "joints": { "$ref": "joints.schema.json#/$defs/skeletonV2WithEyes" }
   },
-  "required": ["scenes", "meshes", "materials", "joints"],
-  "$defs":{
-    "nonCustomizableAvatarTextureCount": {
-      "type": "object",
-      "description": "A non-customizable avatar supports up to 7 materials with 5 maps each, totalling 35 maps.",
-      "properties": {
-        "textures": {
-          "type": "object",
-          "properties": {
-            "properties": {
-              "type": "array",
-              "maxItems": 35,
-              "errorMessage": {
-                "maxItems": "Too many texture maps (${0/length})! This Asset type ${/assetType} must have 35 maps at most."
-              }
-            }
-          }
-        }
-      }
-    }
-  }
+  "required": ["scenes", "meshes", "materials", "textures", "joints"]
 }

--- a/schemas/assetHeroAvatar.schema.json
+++ b/schemas/assetHeroAvatar.schema.json
@@ -246,22 +246,65 @@
               },
               "doubleSided": {
                 "$ref": "commonMaterial.schema.json#/$defs/anySided"
+              }
+            },
+            "allOf": [
+              {
+                "if": {
+                  "properties": {
+                    "name": { "const": "Wolf3D_Eye" }
+                  }
+                },
+                "then": {
+                  "properties": {
+                    "instances": {
+                      "$comment": "Sub-schema properties can't seem to be overridden, so we replicate the structure and reference individual properties.",
+                      "description": "Eyes can use the same material.",
+                      "type": "integer",
+                      "minimum": 1,
+                      "maximum": 2,
+                      "errorMessage": "Material ${1/name} must have 1 or 2 instances."
+                    },
+                    "baseColorFactor": {
+                      "$ref": "commonMaterial.schema.json#/properties/baseColorFactor"
+                    },
+                    "emissiveFactor": {
+                      "$ref": "commonMaterial.schema.json#/properties/emissiveFactor"
+                    },
+                    "metallicFactor": {
+                      "$ref": "commonMaterial.schema.json#/properties/metallicFactor"
+                    },
+                    "roughnessFactor": {
+                      "$ref": "commonMaterial.schema.json#/properties/roughnessFactor"
+                    }
+                  }
+                },
+                "else": {
+                  "allOf": [{ "$ref": "commonMaterial.schema.json" }]
+                }
               },
-              "alphaMode": {
+              {
                 "if": {
                   "properties": {
                     "name": { "const": "Wolf3D_Glasses" }
                   }
                 },
                 "then": {
-                  "$ref": "commonMaterial.schema.json#/$defs/anyAlphaMode"
+                  "properties": {
+                    "alphaMode": {
+                      "$ref": "commonMaterial.schema.json#/$defs/anyAlphaMode"
+                    }
+                  }
                 },
                 "else": {
-                  "$ref": "commonMaterial.schema.json#/$defs/opaqueAlphaMode"
+                  "properties": {
+                    "alphaMode": {
+                      "$ref": "commonMaterial.schema.json#/$defs/opaqueAlphaMode"
+                    }
+                  }
                 }
               }
-            },
-            "allOf": [{ "$ref": "commonMaterial.schema.json" }],
+            ],
             "required": [
               "name",
               "instances",

--- a/schemas/commonMesh.schema.json
+++ b/schemas/commonMesh.schema.json
@@ -36,8 +36,8 @@
     "size": {
       "description": "Byte size. Buffers stored as GLB binary chunk have an implicit limit of (2^32)-1 bytes.",
       "type": "integer",
-      "maximum": 524288,
-      "errorMessage": "Maximum allowed mesh size is 512 kB."
+      "maximum": 2097152,
+      "errorMessage": "Maximum allowed size of each mesh in the file is 2 MB."
     }
   },
   "required": ["mode", "primitives"]

--- a/schemas/gltf-asset.schema.json
+++ b/schemas/gltf-asset.schema.json
@@ -23,7 +23,7 @@
         "hair",
         "headwear",
         "lipshape",
-        "nonCustomizableAvatar",
+        "heroAvatar",
         "noseshape",
         "outfit",
         "shirt",
@@ -31,7 +31,7 @@
       ],
       "errorMessage": {
         "type": "Asset type should be a string.",
-        "enum": "Asset type should be one of the following: beard, bottom, eye, eyebrows, eyeshape, facemask, faceshape, facewear, footwear, glasses, hair, headwear, lipshape, nonCustomizableAvatar, noseshape, outfit, shirt, top. Found ${0}."
+        "enum": "Asset type should be one of the following: beard, bottom, eye, eyebrows, eyeshape, facemask, faceshape, facewear, footwear, glasses, hair, headwear, lipshape, heroAvatar, noseshape, outfit, shirt, top. Found ${0}."
       }
     },
     "transforms": {
@@ -92,7 +92,9 @@
       "then": {
         "allOf": [
           { "$ref": "assetBottom.schema.json" },
-          { "$ref": "commonTexture.schema.json#/$defs/singleMaterialTextureCount" }
+          {
+            "$ref": "commonTexture.schema.json#/$defs/singleMaterialTextureCount"
+          }
         ]
       }
     },
@@ -117,7 +119,9 @@
       "then": {
         "allOf": [
           { "$ref": "assetFootwear.schema.json" },
-          { "$ref": "commonTexture.schema.json#/$defs/singleMaterialTextureCount" }
+          {
+            "$ref": "commonTexture.schema.json#/$defs/singleMaterialTextureCount"
+          }
         ]
       }
     },
@@ -158,17 +162,10 @@
     },
     {
       "if": {
-        "properties": { "assetType": { "const": "nonCustomizableAvatar" } },
+        "properties": { "assetType": { "const": "heroAvatar" } },
         "required": ["assetType"]
       },
-      "then": {
-        "allOf": [
-          { "$ref": "assetNonCustomizableAvatar.schema.json" },
-          {
-            "$ref": "assetNonCustomizableAvatar.schema.json#/$defs/nonCustomizableAvatarTextureCount"
-          }
-        ]
-      }
+      "then": { "$ref": "assetHeroAvatar.schema.json" }
     },
     {
       "if": {
@@ -191,7 +188,9 @@
       "then": {
         "allOf": [
           { "$ref": "assetTop.schema.json" },
-          { "$ref": "commonTexture.schema.json#/$defs/singleMaterialTextureCount" }
+          {
+            "$ref": "commonTexture.schema.json#/$defs/singleMaterialTextureCount"
+          }
         ]
       }
     }

--- a/schemas/materialNames.schema.json
+++ b/schemas/materialNames.schema.json
@@ -15,7 +15,7 @@
     "modularBottom": { "type": "string", "const": "Wolf3D_Outfit_Bottom", "errorMessage": "Material name should be 'Wolf3D_Outfit_Bottom'. Found ${0} instead." },
     "modularFootwear": { "type": "string", "const": "Wolf3D_Outfit_Footwear", "errorMessage": "Material name should be 'Wolf3D_Outfit_Footwear'. Found ${0} instead." },
     "modularTop": { "type": "string", "const": "Wolf3D_Outfit_Top", "errorMessage": "Material name should be 'Wolf3D_Outfit_Top'. Found ${0} instead." },
-    "nonCustomizableAvatar": {
+    "heroAvatar": {
       "enum": [
         "Wolf3D_Body",
         "Wolf3D_Eye",
@@ -23,9 +23,14 @@
         "Wolf3D_Outfit_Footwear",
         "Wolf3D_Outfit_Top",
         "Wolf3D_Skin",
-        "Wolf3D_Teeth"
+        "Wolf3D_Teeth",
+        "Wolf3D_Beard",
+        "Wolf3D_Facewear",
+        "Wolf3D_Glasses",
+        "Wolf3D_Hair",
+        "Wolf3D_Headwear"
       ],
-      "errorMessage": "Material name should be one of 'Wolf3D_Body', 'Wolf3D_Eye', 'Wolf3D_Outfit_Bottom', 'Wolf3D_Outfit_Footwear', 'Wolf3D_Outfit_Top', 'Wolf3D_Skin', 'Wolf3D_Teeth'. Found ${0} instead."
+      "errorMessage": "Material name should be one of 'Wolf3D_Body', 'Wolf3D_Eye', 'Wolf3D_Outfit_Bottom', 'Wolf3D_Outfit_Footwear', 'Wolf3D_Outfit_Top', 'Wolf3D_Skin', 'Wolf3D_Teeth', 'Wolf3D_Beard', 'Wolf3D_Facewear', 'Wolf3D_Glasses', 'Wolf3D_Hair', 'Wolf3D_Headwear'. Found ${0} instead."
     },
     "outfit": {
       "enum": [

--- a/schemas/meshNames.schema.json
+++ b/schemas/meshNames.schema.json
@@ -55,7 +55,7 @@
       "const": "Wolf3D_Outfit_Top",
       "errorMessage": "Mesh name should be 'Wolf3D_Outfit_Top'. Found ${0} instead."
     },
-    "nonCustomizableAvatar": {
+    "heroAvatar": {
       "type": "string",
       "enum": [
         "EyeLeft",
@@ -65,9 +65,14 @@
         "Wolf3D_Outfit_Bottom",
         "Wolf3D_Outfit_Footwear",
         "Wolf3D_Outfit_Top",
-        "Wolf3D_Teeth"
+        "Wolf3D_Teeth",
+        "Wolf3D_Beard",
+        "Wolf3D_Facewear",
+        "Wolf3D_Glasses",
+        "Wolf3D_Hair",
+        "Wolf3D_Headwear"
       ],
-      "errorMessage": "Mesh name should be one of 'EyeLeft', 'EyeRight', 'Wolf3D_Body_Custom', 'Wolf3D_Head_Custom', 'Wolf3D_Outfit_Bottom', 'Wolf3D_Outfit_Footwear', 'Wolf3D_Outfit_Top', 'Wolf3D_Teeth'. Found ${0} instead."
+      "errorMessage": "Mesh name should be one of 'EyeLeft', 'EyeRight', 'Wolf3D_Body_Custom', 'Wolf3D_Head_Custom', 'Wolf3D_Outfit_Bottom', 'Wolf3D_Outfit_Footwear', 'Wolf3D_Outfit_Top', 'Wolf3D_Teeth', 'Wolf3D_Beard', 'Wolf3D_Facewear', 'Wolf3D_Glasses', 'Wolf3D_Hair', 'Wolf3D_Headwear'. Found ${0} instead."
     },
     "outfit": {
       "type": "string",

--- a/schemas/meshTriangleCount.schema.json
+++ b/schemas/meshTriangleCount.schema.json
@@ -37,14 +37,14 @@
       "type": "integer",
       "maximum": 210,
       "errorMessage": {
-        "maximum": "Mesh ${1/name} exceeds triangle count budget. Allowed: 60. Found: ${0}."
+        "maximum": "Mesh ${1/name} exceeds triangle count budget. Allowed: 210. Found: ${0}."
       }
     },
     "facewear": {
       "type": "integer",
-      "maximum": 1000,
+      "maximum": 2000,
       "errorMessage": {
-        "maximum": "Mesh ${1/name} exceeds triangle count budget. Allowed: 900. Found: ${0}."
+        "maximum": "Mesh ${1/name} exceeds triangle count budget. Allowed: 2000. Found: ${0}."
       }
     },
     "glasses": {
@@ -56,9 +56,9 @@
     },
     "hair": {
       "type": "integer",
-      "maximum": 3000,
+      "maximum": 5000,
       "errorMessage": {
-        "maximum": "Mesh ${1/name} exceeds triangle count budget. Allowed: 3000. Found: ${0}."
+        "maximum": "Mesh ${1/name} exceeds triangle count budget. Allowed: 5000. Found: ${0}."
       }
     },
     "head": {
@@ -84,16 +84,16 @@
     },
     "outfitBottom": {
       "type": "integer",
-      "maximum": 6000,
+      "maximum": 7500,
       "errorMessage": {
-        "maximum": "Mesh ${1/name} exceeds triangle count budget. Allowed: 6000. Found: ${0}."
+        "maximum": "Mesh ${1/name} exceeds triangle count budget. Allowed: 7500. Found: ${0}."
       }
     },
     "outfitTop": {
       "type": "integer",
-      "maximum": 6000,
+      "maximum": 9000,
       "errorMessage": {
-        "maximum": "Mesh ${1/name} exceeds triangle count budget. Allowed: 6000. Found: ${0}."
+        "maximum": "Mesh ${1/name} exceeds triangle count budget. Allowed: 9000. Found: ${0}."
       }
     },
     "outfitFootwear": {

--- a/schemas/meshTriangleCount.schema.json
+++ b/schemas/meshTriangleCount.schema.json
@@ -35,14 +35,14 @@
     },
     "eye": {
       "type": "integer",
-      "maximum": 60,
+      "maximum": 210,
       "errorMessage": {
         "maximum": "Mesh ${1/name} exceeds triangle count budget. Allowed: 60. Found: ${0}."
       }
     },
     "facewear": {
       "type": "integer",
-      "maximum": 900,
+      "maximum": 1000,
       "errorMessage": {
         "maximum": "Mesh ${1/name} exceeds triangle count budget. Allowed: 900. Found: ${0}."
       }


### PR DESCRIPTION
We want to allow upload of pre-made avatars in Studio that are not configurable (yet). These assets differ from a fullbody outfit in that they can contain more meshes, including a custom head and body. It’s basically like a downloaded avatar from Ready Player Me with a few tweaks.

The validation schemas have to be updated to account for that. The “nonCustomizableAvatar” will be replaced by a “heroAvatar” asset type.

Task: SRV-525