### PR TITLE
fix(schema): remove default error message

### DIFF
--- a/schemas/gltf-asset.schema.json
+++ b/schemas/gltf-asset.schema.json
@@ -199,7 +199,6 @@
     "type": "Validation data should be a JSON object.",
     "required": {
       "transforms": "Validation data should have a 'transforms' property."
-    },
-    "_": "Asset failed validation against its asset type ${0/assetType}."
+    }
   }
 }


### PR DESCRIPTION
There was a default error message when an asset fails validation.

> "Asset failed validation against its asset type ${0/assetType}."

This message isn’t useful. It was previously used to catch all errors not covered by custom error messages.
In the worst case the message is confusing.

TASK: SRV-593